### PR TITLE
[stage] 배팅 이벤트 핸들링

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 extra["springCloudVersion"] = "2024.0.0-RC1"
 
 dependencies {
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -24,15 +24,15 @@ class Game(
     val type: GameType,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "first_place_team_id", nullable = false)
+    @JoinColumn(name = "first_place_team_id", nullable = true)
     val firstPlaceTeam: Team,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "second_place_team_id", nullable = false)
+    @JoinColumn(name = "second_place_team_id", nullable = true)
     val secondPlaceTeam: Team,
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "third_place_team_id", nullable = false)
+    @JoinColumn(name = "third_place_team_id", nullable = true)
     val thirdPlaceTeam: Team,
 
     @Column(name = "team_count", nullable = false)

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -45,11 +45,21 @@ class Match(
     val isEnd: Boolean,
 
     @Column(name = "a_team_betting_point", nullable = false)
-    val aTeamBettingPoint: Int,
+    var aTeamBettingPoint: Long,
 
     @Column(name = "b_team_betting_point", nullable = false)
-    val bTeamBettingPoint: Int,
-)
+    var bTeamBettingPoint: Long,
+) {
+
+    fun addATeamBettingPoint(bettingPoint: Long) {
+        this.aTeamBettingPoint += bettingPoint
+    }
+
+    fun addBTeamBettingPoint(bettingPoint: Long) {
+        this.bTeamBettingPoint += bettingPoint
+    }
+
+}
 
 enum class Round {
     ROUND_OF_32, ROUND_OF_16, QUARTER_FINALS, SEMI_FINALS, FINALS

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -1,6 +1,9 @@
 package gogo.gogostage.domain.match.root.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface MatchRepository: JpaRepository<Match, Long> {
+    @Query("SELECT m FROM Match m WHERE m.id = :matchId AND m.isEnd = false")
+    fun findNotEndMatchById(matchId: Long): Match?
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.match.root.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MatchRepository: JpaRepository<Match, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -45,7 +45,7 @@ class ParticipateProcessor(
         }
     }
 
-    // 배팅 가능 시간: 경기 시작 24시간 전 ~ 경기 시작 5분 전
+    // 배팅 가능 시간: 매치 시작 24시간 전 ~ 매치 시작 5분 전
     private fun validMatchBettingTime(match: Match) {
         val now = LocalDateTime.now()
         val startDate = match.startDate
@@ -58,6 +58,7 @@ class ParticipateProcessor(
         }
     }
 
+    // 본인이 참여한 매치에는 배팅할 수 없음
     private fun validMatchBetting(match: Match, studentId: Long) {
         val aTeam = match.aTeam
         val bTeam = match.bTeam

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -4,7 +4,6 @@ import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
 import gogo.gogostage.global.error.StageException
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -17,8 +16,8 @@ class ParticipateProcessor(
 
     @Transactional
     fun matchBetting(matchId: Long, studentId: Long, predictedWinTeamId: Long, point: Long) {
-        val match = (matchRepository.findByIdOrNull(matchId)
-            ?: throw StageException("Match Not Found, Match id = $matchId", HttpStatus.NOT_FOUND.value()))
+        val match = matchRepository.findNotEndMatchById(matchId)
+            ?: throw StageException("Match Not Found, Match id = $matchId", HttpStatus.NOT_FOUND.value())
 
         val stage = match.game.stage
         val stageParticipant = stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, studentId)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -1,0 +1,46 @@
+package gogo.gogostage.domain.stage.participant.root.application
+
+import gogo.gogostage.domain.match.root.persistence.Match
+import gogo.gogostage.domain.match.root.persistence.MatchRepository
+import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
+import gogo.gogostage.global.error.StageException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ParticipateProcessor(
+    private val matchRepository: MatchRepository,
+    private val stageParticipantRepository: StageParticipantRepository
+) {
+
+    @Transactional
+    fun matchBetting(matchId: Long, studentId: Long, predictedWinTeamId: Long, point: Long) {
+        val match = (matchRepository.findByIdOrNull(matchId)
+            ?: throw StageException("Match Not Found, Match id = $matchId", HttpStatus.NOT_FOUND.value()))
+
+        val stage = match.game.stage
+        val stageParticipant = stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, studentId)
+                ?: throw StageException("Stage Participant Not Found, Stage id = ${stage.id}, Student id = $studentId", HttpStatus.NOT_FOUND.value())
+
+        stageParticipant.minusPoint(point)
+        updateMatchBettingPointTeam(match, predictedWinTeamId, point)
+
+        stageParticipantRepository.save(stageParticipant)
+        matchRepository.save(match)
+    }
+
+    private fun updateMatchBettingPointTeam(
+        match: Match,
+        predictedWinTeamId: Long,
+        point: Long
+    ) {
+        if (match.aTeam.id == predictedWinTeamId) {
+            match.addATeamBettingPoint(point)
+        } else {
+            match.addBTeamBettingPoint(point)
+        }
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
@@ -20,8 +20,14 @@ class StageParticipant(
     val studentId: Long,
 
     @Column(name = "point", nullable = false)
-    val point: Long,
+    var point: Long,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+
+    fun minusPoint(point: Long) {
+        this.point -= point
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipantRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipantRepository.kt
@@ -10,4 +10,6 @@ interface StageParticipantRepository: JpaRepository<StageParticipant, Long> {
             WHERE s.id = :stageId AND sp.studentId = :studentId AND s.status = :stageStatus
         """)
     fun queryStudentPoint(stageId: Long, studentId: Long, stageStatus: StageStatus): StageParticipant?
+
+    fun queryStageParticipantByStageIdAndStudentId(stageId: Long, studentId: Long): StageParticipant?
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.stage.root.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StageRepository: JpaRepository<Stage, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.team.root.persistence
 
 import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.team.participant.persistence.TeamParticipant
 import jakarta.persistence.*
 
 @Entity
@@ -29,4 +30,7 @@ class Team(
 
     @Column(name = "is_participating", nullable = false)
     val isParticipating: Boolean,
+
+    @OneToMany(mappedBy = "team")
+    val participants: MutableList<TeamParticipant>
 )

--- a/src/main/kotlin/gogo/gogostage/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/gogo/gogostage/global/error/GlobalExceptionHandler.kt
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.NoHandlerFoundException
 class GlobalExceptionHandler {
 
     @ExceptionHandler(StageException::class)
-    fun userExceptionHandler(e: StageException): ResponseEntity<ErrorResponse> =
+    fun stageExceptionHandler(e: StageException): ResponseEntity<ErrorResponse> =
         ResponseEntity(ErrorResponse.of(e), HttpStatus.valueOf(e.status))
 
     @ExceptionHandler(BindException::class)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/KafkaEventPublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/KafkaEventPublisher.kt
@@ -1,0 +1,21 @@
+package gogo.gogostage.global.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.global.publisher.TransactionEventPublisher
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class KafkaEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper
+) : TransactionEventPublisher {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    override fun publishEvent(topic: String, key: String, event: Any) {
+        log.info("Publishing event to topic: $topic, key: $key, event: $event")
+        kafkaTemplate.send(topic, key, objectMapper.writeValueAsString(event))
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -1,0 +1,36 @@
+package gogo.gogostage.global.kafka.configuration
+
+import gogo.gogostage.global.kafka.consumer.MatchBettingConsumer
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+
+@EnableKafka
+@Configuration
+class KafkaConsumerConfig(
+    private val kafkaProperties: KafkaProperties
+) {
+
+    @Bean
+    fun matchBettingEventListenerContainerFactory(listener: MatchBettingConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
+
+    private fun makeFactory(listener: AcknowledgingMessageListener<String, String>): ConcurrentKafkaListenerContainerFactory<String, String> {
+        return ConcurrentKafkaListenerContainerFactory<String, String>().apply {
+            consumerFactory = consumerFactory()
+            containerProperties.ackMode = kafkaProperties.listener.ackMode
+            setConcurrency(3)
+            containerProperties.messageListener = listener
+            containerProperties.pollTimeout = 5000
+        }
+    }
+
+    private fun consumerFactory(): ConsumerFactory<String, String> {
+        return DefaultKafkaConsumerFactory(kafkaProperties.buildConsumerProperties(null))
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
@@ -5,6 +5,7 @@ import gogo.gogostage.domain.stage.participant.root.application.ParticipateProce
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING
+import gogo.gogostage.global.kafka.publisher.StagePublisher
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.kafka.annotation.KafkaListener

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
@@ -1,0 +1,59 @@
+package gogo.gogostage.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.stage.participant.root.application.ParticipateProcessor
+import gogo.gogostage.global.kafka.consumer.dto.MatchBettingEvent
+import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
+import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class MatchBettingConsumer(
+    private val objectMapper: ObjectMapper,
+    private val participateProcessor: ParticipateProcessor,
+    private val stagePublisher: StagePublisher
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [MATCH_BETTING],
+        groupId = "gogo",
+        containerFactory = "matchBettingEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), MatchBettingEvent::class.java)
+        log.info("${MATCH_BETTING}_topic, key: $key, event: $event")
+
+        try {
+
+            participateProcessor.matchBetting(
+                matchId = event.matchId,
+                studentId = event.studentId,
+                predictedWinTeamId = event.predictedWinTeamId,
+                point = event.bettingPoint
+            )
+
+        } catch (e: Exception) {
+            log.error("Failed to Match Betting metch id  = ${event.matchId}, student id = ${event.studentId}")
+
+            stagePublisher.publishMatchBettingFailedEvent(
+                MatchBettingFailedEvent(
+                    id = UUID.randomUUID().toString(),
+                    studentId = event.studentId,
+                    bettingId = event.bettingId,
+                    bettingPoint = event.bettingPoint,
+                )
+            )
+        }
+
+        acknowledgment!!.acknowledge()
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
@@ -42,7 +42,7 @@ class MatchBettingConsumer(
             )
 
         } catch (e: Exception) {
-            log.error("Failed to Match Betting metch id  = ${event.matchId}, student id = ${event.studentId}")
+            log.error("Failed to Match Betting metch id  = ${event.matchId}, student id = ${event.studentId}", e)
 
             stagePublisher.publishMatchBettingFailedEvent(
                 MatchBettingFailedEvent(

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/StagePublisher.kt
@@ -1,0 +1,25 @@
+package gogo.gogostage.global.kafka.consumer
+
+import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
+import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
+import gogo.gogostage.global.publisher.TransactionEventPublisher
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class StagePublisher(
+    private val transactionEventPublisher: TransactionEventPublisher
+){
+
+    fun publishMatchBettingFailedEvent(
+        event: MatchBettingFailedEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = MATCH_BETTING_FAILED,
+            key = key,
+            event = event
+        )
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBettingEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBettingEvent.kt
@@ -1,0 +1,10 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class MatchBettingEvent(
+    val id: String,
+    val studentId: Long,
+    val bettingId: Long,
+    val matchId: Long,
+    val predictedWinTeamId: Long,
+    val bettingPoint: Long,
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBettingFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBettingFailedEvent.kt
@@ -1,0 +1,8 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class MatchBettingFailedEvent(
+    val id: String,
+    val studentId: Long,
+    val bettingId: Long,
+    val bettingPoint: Long,
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.global.kafka.properties
+
+object KafkaTopics {
+    const val MATCH_BETTING = "match_betting"
+    const val MATCH_BETTING_FAILED = "match_betting_failed"
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -1,4 +1,4 @@
-package gogo.gogostage.global.kafka.consumer
+package gogo.gogostage.global.kafka.publisher
 
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED

--- a/src/main/kotlin/gogo/gogostage/global/publisher/TransactionEventPublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/publisher/TransactionEventPublisher.kt
@@ -1,0 +1,5 @@
+package gogo.gogostage.global.publisher
+
+interface TransactionEventPublisher {
+    fun publishEvent(topic: String, key: String, event: Any)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,25 @@ spring:
     redis:
       host: localhost
       port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: gogo
+      auto-offset-reset: earliest
+      properties:
+        spring:
+          json:
+            use:
+              type:
+                headers: 'false'
+            trusted:
+              packages: '*'
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      retries: 1
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    listener:
+      ack-mode: manual
+      poll-timeout: 5000


### PR DESCRIPTION
## 개요
배팅 완료시 발행하는 이벤트를 Stage 서비스가 핸들링하는 작업을 작성하였습니다.

## 본문
1. 배팅 서비스에서 배팅 완료시 `match_betting` 토픽에 발행한 이벤트를 Stage 서비스에서 컨슘합니다.
2. 해당 배팅이 유효한지 검증합니다. (a. 배팅 가능 시간인가?, b. 해당 매치에 배팅한 학생이 출전하는가?)
3. 이벤트 본문에 따라 해당 학생의 포인트를 차감합니다.
   2.1 Match에 총 배팅된 포인트를 올리는 작업이 포함되어 있어 추후에 캐싱 적용시 캐시 업데이트가 필요합니다.
4. 해당 Match에 배팅한 Team에 배팅한 포인트를 추가하여 업데이트합니다.

- 만약 차감 작업이 실패시 위 작업의 트랜잭션은 롤백 되고 `match_betting_failed` 이벤트를 발행하여 배팅 서비스의 보상 트랜잭션 작업을 요구합니다.