### PR TITLE
[stage] 배팅 정산 이벤트 핸들링

### DIFF
--- a/src/main/kotlin/gogo/gogostage/GogoStageApplication.kt
+++ b/src/main/kotlin/gogo/gogostage/GogoStageApplication.kt
@@ -2,7 +2,9 @@ package gogo.gogostage
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 class GogoStageApplication
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
@@ -3,6 +3,7 @@ package gogo.gogostage.domain.match.result.persistence
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.team.root.persistence.Team
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tbl_match_result")
@@ -10,7 +11,7 @@ class MatchResult(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    val id: Long,
+    val id: Long = 0,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "match_id", nullable = false)
@@ -24,5 +25,18 @@ class MatchResult(
     val aTeamScore: Int,
 
     @Column(name = "b_team_score", nullable = false)
-    val bTeamScore: Int
-)
+    val bTeamScore: Int,
+
+    val createdAt: LocalDateTime = LocalDateTime.now()
+) {
+    companion object {
+
+        fun of(match: Match, victoryTeam: Team, aTeamScore: Int, bTeamScore: Int)= MatchResult(
+            match = match,
+            victoryTeam = victoryTeam,
+            aTeamScore = aTeamScore,
+            bTeamScore = bTeamScore
+        )
+
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.match.result.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MatchResultRepository: JpaRepository<MatchResult, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -42,7 +42,7 @@ class Match(
     val endDate: LocalDateTime,
 
     @Column(name = "is_end", nullable = false)
-    val isEnd: Boolean,
+    var isEnd: Boolean,
 
     @Column(name = "a_team_betting_point", nullable = false)
     var aTeamBettingPoint: Long,
@@ -50,6 +50,10 @@ class Match(
     @Column(name = "b_team_betting_point", nullable = false)
     var bTeamBettingPoint: Long,
 ) {
+
+    fun end() {
+        isEnd = true
+    }
 
     fun addATeamBettingPoint(bettingPoint: Long) {
         this.aTeamBettingPoint += bettingPoint

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
@@ -30,4 +30,8 @@ class StageParticipant(
         this.point -= point
     }
 
+    fun plusPoint(point: Long) {
+        this.point += point
+    }
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -1,0 +1,67 @@
+package gogo.gogostage.domain.stage.participant.temppoint.application
+
+import gogo.gogostage.domain.match.result.persistence.MatchResult
+import gogo.gogostage.domain.match.result.persistence.MatchResultRepository
+import gogo.gogostage.domain.match.root.persistence.MatchRepository
+import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
+import gogo.gogostage.domain.stage.participant.temppoint.persistence.TempPoint
+import gogo.gogostage.domain.stage.participant.temppoint.persistence.TempPointRepository
+import gogo.gogostage.domain.team.root.persistence.TeamRepository
+import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.kafka.consumer.dto.MatchBatchEvent
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Component
+class TempPointProcessor(
+    private val matchRepository: MatchRepository,
+    private val stageParticipantRepository: StageParticipantRepository,
+    private val tempPointRepository: TempPointRepository,
+    private val teamRepository: TeamRepository,
+    private val matchResultRepository: MatchResultRepository,
+) {
+
+    @Transactional
+    fun addTempPoint(event: MatchBatchEvent) {
+        val match = (matchRepository.findNotEndMatchById(event.matchId)
+            ?: throw StageException("Match Not Found, Match Id = ${event.matchId}", HttpStatus.NOT_FOUND.value()))
+        val stage = match.game.stage
+
+        val victoryTeam = teamRepository.findByIdOrNull(event.victoryTeamId)
+            ?: throw StageException(
+                "Victory Team Not Found, Team Id = ${event.victoryTeamId}",
+                HttpStatus.NOT_FOUND.value()
+            )
+
+        val matchResult = MatchResult.of(
+            match = match,
+            victoryTeam = victoryTeam,
+            aTeamScore = event.aTeamScore,
+            bTeamScore = event.bTeamScore,
+        )
+        matchResultRepository.save(matchResult)
+
+        val expiredDate = LocalDateTime.now().plusMinutes(5)
+        val tempPoints = event.students.map { student ->
+            val stageParticipant =
+                stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, student.studentId)
+                    ?: throw StageException(
+                        "Stage Participant Not Found, Stage Id = ${stage.id}, Student Id = ${student.studentId}",
+                        HttpStatus.NOT_FOUND.value()
+                    )
+
+            TempPoint.of(
+                stageParticipant = stageParticipant,
+                match = match,
+                batchId = event.batchId,
+                tempPoint = student.earnedPoint,
+                tempPointExpiredDate = expiredDate
+            )
+        }
+        tempPointRepository.saveAll(tempPoints)
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import kotlin.math.roundToLong
 
 @Component
 class TempPointProcessor(
@@ -29,6 +30,7 @@ class TempPointProcessor(
         val match = (matchRepository.findNotEndMatchById(event.matchId)
             ?: throw StageException("Match Not Found, Match Id = ${event.matchId}", HttpStatus.NOT_FOUND.value()))
         val stage = match.game.stage
+        val totalBettingPoint = match.aTeamBettingPoint + match.bTeamBettingPoint
 
         val victoryTeam = teamRepository.findByIdOrNull(event.victoryTeamId)
             ?: throw StageException(
@@ -47,9 +49,9 @@ class TempPointProcessor(
         )
         matchResultRepository.save(matchResult)
 
-        // 정산 취소시 동시성 문제 발생을 방지하기 위해 5분 5초 후 만료되도록 설정
+        // * 정산 취소시 동시성 문제 발생을 방지하기 위해 5분 5초 후 만료되도록 설정
         val expiredDate = LocalDateTime.now().plusMinutes(5).plusSeconds(5)
-        val tempPoints = event.students.map { student ->
+        val predictionTempPoints = event.students.map { student ->
             val stageParticipant =
                 stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, student.studentId)
                     ?: throw StageException(
@@ -65,7 +67,26 @@ class TempPointProcessor(
                 tempPointExpiredDate = expiredDate
             )
         }
-        tempPointRepository.saveAll(tempPoints)
+        tempPointRepository.saveAll(predictionTempPoints)
+
+        // * 해당 매치의 승리 팀 선수들은 해당 매치에 배팅된 포인트의 10%씩 임시포인트 지급
+        val victoryTempPoint = victoryTeam.participants.map { participant ->
+            val stageParticipant =
+                stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, participant.studentId)
+                    ?: throw StageException(
+                        "Stage Participant Not Found, Stage Id = ${stage.id}, Student Id = ${participant.studentId}",
+                        HttpStatus.NOT_FOUND.value()
+                    )
+
+            TempPoint.of(
+                stageParticipant = stageParticipant,
+                match = match,
+                batchId = event.batchId,
+                tempPoint = (totalBettingPoint * 0.1).roundToLong(),
+                tempPointExpiredDate = expiredDate
+            )
+        }
+        tempPointRepository.saveAll(victoryTempPoint)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -36,6 +36,9 @@ class TempPointProcessor(
                 HttpStatus.NOT_FOUND.value()
             )
 
+        match.end()
+        matchRepository.save(match)
+
         val matchResult = MatchResult.of(
             match = match,
             victoryTeam = victoryTeam,
@@ -44,7 +47,8 @@ class TempPointProcessor(
         )
         matchResultRepository.save(matchResult)
 
-        val expiredDate = LocalDateTime.now().plusMinutes(5)
+        // 정산 취소시 동시성 문제 발생을 방지하기 위해 5분 5초 후 만료되도록 설정
+        val expiredDate = LocalDateTime.now().plusMinutes(5).plusSeconds(5)
         val tempPoints = event.students.map { student ->
             val stageParticipant =
                 stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(stage.id, student.studentId)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPoint.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPoint.kt
@@ -31,8 +31,13 @@ class TempPoint(
     val tempPointExpiredDate: LocalDateTime,
 
     @Column(name = "is_applied")
-    val isApplied: Boolean
+    var isApplied: Boolean
 ) {
+
+    fun applied() {
+        isApplied = true
+    }
+
     companion object {
 
         fun of(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPoint.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPoint.kt
@@ -11,7 +11,7 @@ class TempPoint(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    val id: Long,
+    val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "stage_participant_id")
@@ -32,4 +32,23 @@ class TempPoint(
 
     @Column(name = "is_applied")
     val isApplied: Boolean
-)
+) {
+    companion object {
+
+        fun of(
+            stageParticipant: StageParticipant,
+            match: Match,
+            batchId: Long,
+            tempPoint: Long,
+            tempPointExpiredDate: LocalDateTime
+        ) = TempPoint(
+            stageParticipant = stageParticipant,
+            match = match,
+            batchId = batchId,
+            tempPoint = tempPoint,
+            tempPointExpiredDate = tempPointExpiredDate,
+            isApplied = false
+        )
+
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.stage.participant.temppoint.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TempPointRepository: JpaRepository<TempPoint, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
@@ -1,6 +1,10 @@
 package gogo.gogostage.domain.stage.participant.temppoint.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface TempPointRepository: JpaRepository<TempPoint, Long> {
+    @Query("SELECT t FROM TempPoint t WHERE t.isApplied = false AND t.tempPointExpiredDate <= :now")
+    fun findExpiredTempPoints(now: LocalDateTime): List<TempPoint>
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.team.root.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TeamRepository: JpaRepository<Team, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.global.kafka.configuration
 
+import gogo.gogostage.global.kafka.consumer.MatchBatchConsumer
 import gogo.gogostage.global.kafka.consumer.MatchBettingConsumer
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
@@ -18,6 +19,10 @@ class KafkaConsumerConfig(
 
     @Bean
     fun matchBettingEventListenerContainerFactory(listener: MatchBettingConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
+
+    @Bean
+    fun matchBatchEventListenerContainerFactory(listener: MatchBatchConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
         makeFactory(listener)
 
     private fun makeFactory(listener: AcknowledgingMessageListener<String, String>): ConcurrentKafkaListenerContainerFactory<String, String> {

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
@@ -1,0 +1,53 @@
+package gogo.gogostage.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.stage.participant.temppoint.application.TempPointProcessor
+import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
+import gogo.gogostage.global.kafka.consumer.dto.MatchBatchEvent
+import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BATCH
+import gogo.gogostage.global.kafka.publisher.StagePublisher
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class MatchBatchConsumer(
+    private val objectMapper: ObjectMapper,
+    private val tempPointProcessor: TempPointProcessor,
+    private val stagePublisher: StagePublisher
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [MATCH_BATCH],
+        groupId = "gogo",
+        containerFactory = "matchBettingEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), MatchBatchEvent::class.java)
+        log.info("${MATCH_BATCH}_topic, key: $key, event: $event")
+
+        try {
+
+            tempPointProcessor.addTempPoint(event)
+
+        } catch (e: Exception) {
+            log.error("Failed to Batch Addition Temp Point, Batch Id = ${event.batchId}", e)
+
+            stagePublisher.publishBatchAdditionTempPointFailedEvent(
+                BatchAdditionTempPointFailedEvent(
+                    id = UUID.randomUUID().toString(),
+                    batchId = event.batchId,
+                )
+            )
+        }
+
+        acknowledgment!!.acknowledge()
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
@@ -26,7 +26,7 @@ class MatchBatchConsumer(
     @KafkaListener(
         topics = [MATCH_BATCH],
         groupId = "gogo",
-        containerFactory = "matchBettingEventListenerContainerFactory"
+        containerFactory = "matchBatchEventListenerContainerFactory"
     )
     override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
         val (key, event) = data.key() to objectMapper.readValue(data.value(), MatchBatchEvent::class.java)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBettingConsumer.kt
@@ -42,7 +42,7 @@ class MatchBettingConsumer(
             )
 
         } catch (e: Exception) {
-            log.error("Failed to Match Betting metch id  = ${event.matchId}, student id = ${event.studentId}", e)
+            log.error("Failed to Match Betting Match Id  = ${event.matchId}, Student Id = ${event.studentId}", e)
 
             stagePublisher.publishMatchBettingFailedEvent(
                 MatchBettingFailedEvent(

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchAdditionTempPointFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchAdditionTempPointFailedEvent.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class BatchAdditionTempPointFailedEvent(
+    val id: String,
+    val batchId: Long,
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
@@ -1,12 +1,14 @@
 package gogo.gogostage.global.kafka.consumer.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class MatchBatchEvent(
     val id: String,
     val batchId: Long,
     val matchId: Long,
     val victoryTeamId: Long,
-    val aTeamScore: Int,
-    val bTeamScore: Int,
+    @JsonProperty("ateamScore") val aTeamScore: Int,
+    @JsonProperty("bteamScore") val bTeamScore: Int,
     val students: List<StudentBettingDto>
 )
 

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
@@ -1,0 +1,16 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class MatchBatchEvent(
+    val id: String,
+    val batchId: Long,
+    val matchId: Long,
+    val victoryTeamId: Long,
+    val aTeamScore: Int,
+    val bTeamScore: Int,
+    val students: List<StudentBettingDto>
+)
+
+data class StudentBettingDto(
+    val studentId: Long,
+    val earnedPoint: Long
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -3,4 +3,6 @@ package gogo.gogostage.global.kafka.properties
 object KafkaTopics {
     const val MATCH_BETTING = "match_betting"
     const val MATCH_BETTING_FAILED = "match_betting_failed"
+    const val MATCH_BATCH = "match_batch"
+    const val BATCH_ADDITION_TEMP_POINT_FAILED = "batch_addition_temp_point_failed"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -1,6 +1,8 @@
 package gogo.gogostage.global.kafka.publisher
 
+import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
+import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_ADDITION_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
 import gogo.gogostage.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
@@ -17,6 +19,17 @@ class StagePublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = MATCH_BETTING_FAILED,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishBatchAdditionTempPointFailedEvent(
+        event: BatchAdditionTempPointFailedEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = BATCH_ADDITION_TEMP_POINT_FAILED,
             key = key,
             event = event
         )

--- a/src/main/kotlin/gogo/gogostage/global/schedule/TempPointScheduler.kt
+++ b/src/main/kotlin/gogo/gogostage/global/schedule/TempPointScheduler.kt
@@ -1,0 +1,32 @@
+package gogo.gogostage.global.schedule
+
+import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
+import gogo.gogostage.domain.stage.participant.temppoint.persistence.TempPointRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Component
+class TempPointScheduler(
+    private val tempPointRepository: TempPointRepository,
+    private val stageParticipantRepository: StageParticipantRepository
+) {
+
+    @Transactional
+    @Scheduled(fixedRate = 30000)
+    fun applyExpiredTempPoints() {
+        val now = LocalDateTime.now()
+        val expiredTempPoints = tempPointRepository.findExpiredTempPoints(now)
+
+        expiredTempPoints.forEach { tempPoint ->
+            val participant = tempPoint.stageParticipant
+            participant.plusPoint(tempPoint.tempPoint)
+            tempPoint.applied()
+        }
+
+        stageParticipantRepository.saveAll(expiredTempPoints.map { it.stageParticipant })
+        tempPointRepository.saveAll(expiredTempPoints)
+    }
+
+}


### PR DESCRIPTION
# 개요
배팅 서비스에서 정산 후 이벤트를 컨슘하여 예측에 성공한 학생들의 **임시포인트를 지급, 매치 결과 저장, 매치 종료 처리**하는 기능을 개발하였습니다.

## 본문
- `match_batch` 토픽의 이벤트를 컨슘하여 예측 성공한 학생에게 임시포인트 지급, 매치 결과 저장, 매치 종료 처리를 진행합니다.
- 임시포인트는 5분 5초 후의 시간으로 만료 시간을 설정하여 저장합니다. (`TempPointScheduler` 스케쥴러가 30초마다 만료시간을 확인하여 포인트로 합산합니다.)
- 해당 매치의 승리팀 학생들에게 해당 매치에 배팅된 포인트 10%씩 임시포인트로 지급합니다.
- 해당 작업을 진행하다 예외가 발생시 `batch_addition_temp_point_failed` 이벤트를 발행합니다. 해당 이벤트를 컨슘한 Betting 서비스에서 해당 정산에 대한 보상 트랜잭션을 실행시키길 기대합니다.