### PR TITLE
[stage] 정산 취소 이벤트 핸들링

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
@@ -3,4 +3,5 @@ package gogo.gogostage.domain.match.result.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MatchResultRepository: JpaRepository<MatchResult, Long> {
+    fun deleteByMatchId(matchId: Long)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
@@ -3,6 +3,7 @@ package gogo.gogostage.domain.match.root.application
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.global.error.StageException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 
@@ -12,7 +13,7 @@ class MatchReader(
 ) {
 
     fun read(matchId: Long): Match =
-        matchRepository.findNotEndMatchById(matchId)
+        matchRepository.findByIdOrNull(matchId)
             ?: throw StageException("Match not found, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -55,6 +55,10 @@ class Match(
         isEnd = true
     }
 
+    fun batchRollback() {
+        isEnd = false
+    }
+
     fun addATeamBettingPoint(bettingPoint: Long) {
         this.aTeamBettingPoint += bettingPoint
     }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
@@ -1,10 +1,17 @@
 package gogo.gogostage.domain.stage.participant.temppoint.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface TempPointRepository: JpaRepository<TempPoint, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT t FROM TempPoint t WHERE t.isApplied = false AND t.tempPointExpiredDate <= :now")
     fun findExpiredTempPoints(now: LocalDateTime): List<TempPoint>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM TempPoint t WHERE t.isApplied = false AND t.tempPointExpiredDate > :now AND t.batchId = :batchId")
+    fun findNotAppliedByBatchId(now: LocalDateTime, batchId: Long): List<TempPoint>
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.global.kafka.configuration
 
+import gogo.gogostage.global.kafka.consumer.BatchCancelConsumer
 import gogo.gogostage.global.kafka.consumer.MatchBatchConsumer
 import gogo.gogostage.global.kafka.consumer.MatchBettingConsumer
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
@@ -23,6 +24,10 @@ class KafkaConsumerConfig(
 
     @Bean
     fun matchBatchEventListenerContainerFactory(listener: MatchBatchConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
+
+    @Bean
+    fun batchCancelEventListenerContainerFactory(listener: BatchCancelConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
         makeFactory(listener)
 
     private fun makeFactory(listener: AcknowledgingMessageListener<String, String>): ConcurrentKafkaListenerContainerFactory<String, String> {

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchCancelDeleteTempPointFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchCancelDeleteTempPointFailedEvent.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class BatchCancelDeleteTempPointFailedEvent(
+    val id: String,
+    val batchId: Long
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchCancelEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/BatchCancelEvent.kt
@@ -1,0 +1,7 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class BatchCancelEvent(
+    val id: String,
+    val batchId: Long,
+    val matchId: Long,
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -5,4 +5,6 @@ object KafkaTopics {
     const val MATCH_BETTING_FAILED = "match_betting_failed"
     const val MATCH_BATCH = "match_batch"
     const val BATCH_ADDITION_TEMP_POINT_FAILED = "batch_addition_temp_point_failed"
+    const val BATCH_CANCEL = "batch_cancel"
+    const val BATCH_CANCEL_DELETE_TEMP_POINT_FAILED = "batch_cancel_delete_temp_point_failed"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -1,8 +1,10 @@
 package gogo.gogostage.global.kafka.publisher
 
 import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
+import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_ADDITION_TEMP_POINT_FAILED
+import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
 import gogo.gogostage.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
@@ -30,6 +32,17 @@ class StagePublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = BATCH_ADDITION_TEMP_POINT_FAILED,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishBatchCancelDeleteTempPointFailedEvent(
+        event: BatchCancelDeleteTempPointFailedEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = BATCH_CANCEL_DELETE_TEMP_POINT_FAILED,
             key = key,
             event = event
         )


### PR DESCRIPTION
## 개요
Betting 서비스에서 발급하는 정산 취소 이벤트를 핸들링합니다.

## 본문
- batch_cancel 이벤트를 핸들링하여 해당 배치에 대한 임시 포인트를 삭제합니다.
   - 만약 임시포인트가 이미 반영되었다면 batch_cancel_delete_temp_point_failed 이벤트를 발행하며 Betting 서비스에서 취소된 정산을 복구하기를 기대합니다.