### PR TITLE
[stage] 스테이지(공식) 생성 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/Community.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/Community.kt
@@ -12,7 +12,7 @@ class Community(
     @Column(name = "id", nullable = false)
     val id: Long = 0,
 
-    @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @ManyToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     @JoinColumn(name = "stage_id", nullable = false)
     val stage: Stage,
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/minigameinfo/persistence/MiniGameInfo.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/minigameinfo/persistence/MiniGameInfo.kt
@@ -1,5 +1,7 @@
 package gogo.gogostage.domain.stage.minigameinfo.persistence
 
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageMiniGameDto
+import gogo.gogostage.domain.stage.root.application.dto.MiniGameInfoDto
 import gogo.gogostage.domain.stage.root.persistence.Stage
 import jakarta.persistence.*
 
@@ -31,6 +33,13 @@ class MiniGameInfo(
             isActiveCoinToss = isActiveCoinToss,
             isActiveYavarwee = false,
             isActivePlinko = false,
+        )
+
+        fun officialOf(stage: Stage, miniGameInfo: CreateOfficialStageMiniGameDto) = MiniGameInfo(
+            stage = stage,
+            isActiveCoinToss = miniGameInfo.coinToss.isActive,
+            isActiveYavarwee = miniGameInfo.yavarwee.isActive,
+            isActivePlinko = miniGameInfo.plinko.isActive,
         )
 
     }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/minigameinfo/persistence/MiniGameInfo.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/minigameinfo/persistence/MiniGameInfo.kt
@@ -1,7 +1,6 @@
 package gogo.gogostage.domain.stage.minigameinfo.persistence
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageMiniGameDto
-import gogo.gogostage.domain.stage.root.application.dto.MiniGameInfoDto
 import gogo.gogostage.domain.stage.root.persistence.Stage
 import jakarta.persistence.*
 
@@ -28,7 +27,7 @@ class MiniGameInfo(
 ) {
     companion object {
 
-        fun ofFast(stage: Stage, isActiveCoinToss: Boolean) = MiniGameInfo(
+        fun fastOf(stage: Stage, isActiveCoinToss: Boolean) = MiniGameInfo(
             stage = stage,
             isActiveCoinToss = isActiveCoinToss,
             isActiveYavarwee = false,

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
@@ -1,0 +1,45 @@
+package gogo.gogostage.domain.stage.root.application
+
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
+import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
+import gogo.gogostage.domain.stage.root.event.OfficialStageMiniGameDto
+import gogo.gogostage.domain.stage.root.event.OfficialStageShopDto
+import gogo.gogostage.domain.stage.root.event.OfficialStageShopInfoDto
+import gogo.gogostage.domain.stage.root.persistence.Stage
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class StageMapper {
+
+    fun mapCreateOfficialEvent(
+        stage: Stage,
+        dto: CreateOfficialStageDto
+    ) = CreateStageOfficialEvent(
+        id = UUID.randomUUID().toString(),
+        stageId = stage.id,
+        miniGame = OfficialStageMiniGameDto(
+            isCoinTossActive = dto.miniGame.coinToss.isActive,
+            isYavarweeActive = dto.miniGame.yavarwee.isActive,
+            isPlinkoActive = dto.miniGame.plinko.isActive
+        ),
+        shop = OfficialStageShopDto(
+            coinToss = OfficialStageShopInfoDto(
+                isActive = dto.shop.coinToss.isActive,
+                price = dto.shop.coinToss.price,
+                quantity = dto.shop.coinToss.quantity,
+            ),
+            yavarwee = OfficialStageShopInfoDto(
+                isActive = dto.shop.yavarwee.isActive,
+                price = dto.shop.yavarwee.price,
+                quantity = dto.shop.yavarwee.quantity,
+            ),
+            plinko = OfficialStageShopInfoDto(
+                isActive = dto.shop.plinko.isActive,
+                price = dto.shop.plinko.price,
+                quantity = dto.shop.plinko.quantity,
+            ),
+        )
+    )
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
@@ -1,10 +1,7 @@
 package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
-import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
-import gogo.gogostage.domain.stage.root.event.OfficialStageMiniGameDto
-import gogo.gogostage.domain.stage.root.event.OfficialStageShopDto
-import gogo.gogostage.domain.stage.root.event.OfficialStageShopInfoDto
+import gogo.gogostage.domain.stage.root.event.*
 import gogo.gogostage.domain.stage.root.persistence.Stage
 import org.springframework.stereotype.Component
 import java.util.*
@@ -19,9 +16,21 @@ class StageMapper {
         id = UUID.randomUUID().toString(),
         stageId = stage.id,
         miniGame = OfficialStageMiniGameDto(
-            isCoinTossActive = dto.miniGame.coinToss.isActive,
-            isYavarweeActive = dto.miniGame.yavarwee.isActive,
-            isPlinkoActive = dto.miniGame.plinko.isActive
+            coinToss = OfficialStageMiniGameInfoDto(
+                isActive = dto.miniGame.coinToss.isActive,
+                maxBettingPoint = dto.miniGame.coinToss.maxBettingPoint,
+                minBettingPoint = dto.miniGame.coinToss.minBettingPoint,
+            ),
+            yavarwee = OfficialStageMiniGameInfoDto(
+                isActive = dto.miniGame.yavarwee.isActive,
+                maxBettingPoint = dto.miniGame.yavarwee.maxBettingPoint,
+                minBettingPoint = dto.miniGame.yavarwee.minBettingPoint,
+            ),
+            plinko = OfficialStageMiniGameInfoDto(
+                isActive = dto.miniGame.plinko.isActive,
+                maxBettingPoint = dto.miniGame.plinko.maxBettingPoint,
+                minBettingPoint = dto.miniGame.plinko.minBettingPoint,
+            )
         ),
         shop = OfficialStageShopDto(
             coinToss = OfficialStageShopInfoDto(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
@@ -75,7 +75,8 @@ class StageProcessor(
         val games = dto.game.map { Game.of(stage, it.category, it.name, it.system) }
         gameRepository.saveAll(games)
 
-        val communities = games.map { Community.of(it) }
+        val gameCategories = games.map { it.category }.toSet().toList()
+        val communities = gameCategories.map { Community.of(stage, it) }
         communityRepository.saveAll(communities)
 
         return stage

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
@@ -33,7 +33,7 @@ class StageProcessor(
         val stage = Stage.fastOf(student, dto, isActiveCoinToss)
         stageRepository.save(stage)
 
-        val miniGameInfo = MiniGameInfo.ofFast(stage, isActiveCoinToss)
+        val miniGameInfo = MiniGameInfo.fastOf(stage, isActiveCoinToss)
         miniGameInfoRepository.save(miniGameInfo)
 
         val stageRule = StageRule.of(stage, dto.rule)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageService.kt
@@ -1,7 +1,9 @@
 package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 
 interface StageService {
     fun createFast(dto: CreateFastStageDto)
+    fun createOfficial(dto: CreateOfficialStageDto)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -2,10 +2,7 @@ package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
-import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
-import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
-import gogo.gogostage.domain.stage.root.event.FastStageMiniGameDto
-import gogo.gogostage.domain.stage.root.event.OfficialStageMiniGameInfoDto
+import gogo.gogostage.domain.stage.root.event.*
 import gogo.gogostage.global.util.UserContextUtil
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -17,6 +14,7 @@ class StageServiceImpl(
     private val userUtil: UserContextUtil,
     private val stageProcessor: StageProcessor,
     private val stageValidator: StageValidator,
+    private val stageMapper: StageMapper,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) : StageService {
 
@@ -43,22 +41,8 @@ class StageServiceImpl(
         stageValidator.validOfficial(dto)
         val stage = stageProcessor.saveOfficial(student, dto)
 
-        applicationEventPublisher.publishEvent(
-            CreateStageOfficialEvent(
-                id = UUID.randomUUID().toString(),
-                stageId = stage.id,
-                miniGame = OfficialStageMiniGameInfoDto(
-                    isCoinTossActive = dto.miniGame.coinToss.isActive,
-                    isYavarweeActive = dto.miniGame.yavarwee.isActive,
-                    isPlinkoActive = dto.miniGame.plinko.isActive
-                ),
-                shop = OfficialStageMiniGameInfoDto(
-                    isCoinTossActive = dto.shop.coinToss.isActive,
-                    isYavarweeActive = dto.shop.yavarwee.isActive,
-                    isPlinkoActive = dto.shop.plinko.isActive
-                )
-            )
-        )
+        val event = stageMapper.mapCreateOfficialEvent(stage, dto)
+        applicationEventPublisher.publishEvent(event)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -3,7 +3,9 @@ package gogo.gogostage.domain.stage.root.application
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
+import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
 import gogo.gogostage.domain.stage.root.event.FastStageMiniGameDto
+import gogo.gogostage.domain.stage.root.event.OfficialStageMiniGameInfoDto
 import gogo.gogostage.global.util.UserContextUtil
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -40,6 +42,23 @@ class StageServiceImpl(
         val student = userUtil.getCurrentStudent()
         stageValidator.valid(dto.maintainer)
         val stage = stageProcessor.saveOfficial(student, dto)
+
+        applicationEventPublisher.publishEvent(
+            CreateStageOfficialEvent(
+                id = UUID.randomUUID().toString(),
+                stageId = stage.id,
+                miniGame = OfficialStageMiniGameInfoDto(
+                    isCoinTossActive = dto.miniGame.coinToss.isActive,
+                    isYavarweeActive = dto.miniGame.yavarwee.isActive,
+                    isPlinkoActive = dto.miniGame.plinko.isActive
+                ),
+                shop = OfficialStageMiniGameInfoDto(
+                    isCoinTossActive = dto.shop.coinToss.isActive,
+                    isYavarweeActive = dto.shop.yavarwee.isActive,
+                    isPlinkoActive = dto.shop.plinko.isActive
+                )
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -23,7 +23,7 @@ class StageServiceImpl(
     @Transactional
     override fun createFast(dto: CreateFastStageDto) {
         val student = userUtil.getCurrentStudent()
-        stageValidator.valid(dto.maintainer)
+        stageValidator.validFast(dto)
         val stage = stageProcessor.saveFast(student, dto)
 
         applicationEventPublisher.publishEvent(
@@ -40,7 +40,7 @@ class StageServiceImpl(
     @Transactional
     override fun createOfficial(dto: CreateOfficialStageDto) {
         val student = userUtil.getCurrentStudent()
-        stageValidator.valid(dto.maintainer)
+        stageValidator.validOfficial(dto)
         val stage = stageProcessor.saveOfficial(student, dto)
 
         applicationEventPublisher.publishEvent(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
 import gogo.gogostage.domain.stage.root.event.FastStageMiniGameDto
 import gogo.gogostage.global.util.UserContextUtil
@@ -32,6 +33,13 @@ class StageServiceImpl(
                 )
             )
         )
+    }
+
+    @Transactional
+    override fun createOfficial(dto: CreateOfficialStageDto) {
+        val student = userUtil.getCurrentStudent()
+        stageValidator.valid(dto.maintainer)
+        val stage = stageProcessor.saveOfficial(student, dto)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -29,29 +29,29 @@ class StageValidator {
     }
 
     private fun validShop(dto: CreateOfficialStageDto) {
-        if (dto.shop.coinToss.isActive && dto.shop.coinToss.price == null || dto.shop.coinToss.quantity == null) {
+        if (dto.shop.coinToss.isActive && (dto.shop.coinToss.price == null || dto.shop.coinToss.quantity == null)) {
             throw StageException("CoinToss 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.shop.yavarwee.isActive && dto.shop.yavarwee.price == null || dto.shop.yavarwee.quantity == null) {
+        if (dto.shop.yavarwee.isActive && (dto.shop.yavarwee.price == null || dto.shop.yavarwee.quantity == null)) {
             throw StageException("Yavarwee 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.shop.plinko.isActive && dto.shop.plinko.price == null || dto.shop.plinko.quantity == null) {
+        if (dto.shop.plinko.isActive && (dto.shop.plinko.price == null || dto.shop.plinko.quantity == null)) {
             throw StageException("Plinko 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
     }
 
     private fun validMiniGame(dto: CreateOfficialStageDto) {
-        if (dto.miniGame.coinToss.isActive && dto.miniGame.coinToss.maxBettingPoint == null) {
+        if (dto.miniGame.coinToss.isActive && (dto.miniGame.coinToss.maxBettingPoint == null)) {
             throw StageException("CoinToss 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.miniGame.yavarwee.isActive && dto.miniGame.yavarwee.maxBettingPoint == null) {
+        if (dto.miniGame.yavarwee.isActive && (dto.miniGame.yavarwee.maxBettingPoint == null)) {
             throw StageException("Yavarwee 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.miniGame.plinko.isActive && dto.miniGame.plinko.maxBettingPoint == null) {
+        if (dto.miniGame.plinko.isActive && (dto.miniGame.plinko.maxBettingPoint == null)) {
             throw StageException("Plinko 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
     }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -1,5 +1,7 @@
 package gogo.gogostage.domain.stage.root.application
 
+import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import gogo.gogostage.global.error.StageException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -7,9 +9,50 @@ import org.springframework.stereotype.Component
 @Component
 class StageValidator {
 
-    fun valid(maintainer: List<Long>) {
-        if (maintainer.size > 5) {
+    fun validFast(dto: CreateFastStageDto) {
+        if (dto.maintainer.size > 5) {
             throw StageException("스테이지 관리자는 최대 5명까지 가능합니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.miniGame.coinToss.isActive && dto.miniGame.coinToss.maxBettingPoint == null) {
+            throw StageException("CoinToss 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+    fun validOfficial(dto: CreateOfficialStageDto) {
+        if (dto.maintainer.size > 5) {
+            throw StageException("스테이지 관리자는 최대 5명까지 가능합니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        validMiniGame(dto)
+        validShop(dto)
+    }
+
+    private fun validShop(dto: CreateOfficialStageDto) {
+        if (dto.shop.coinToss.isActive && dto.shop.coinToss.price == null || dto.shop.coinToss.quantity == null) {
+            throw StageException("CoinToss 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.shop.yavarwee.isActive && dto.shop.yavarwee.price == null || dto.shop.yavarwee.quantity == null) {
+            throw StageException("Yavarwee 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.shop.plinko.isActive && dto.shop.plinko.price == null || dto.shop.plinko.quantity == null) {
+            throw StageException("Plinko 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+    private fun validMiniGame(dto: CreateOfficialStageDto) {
+        if (dto.miniGame.coinToss.isActive && dto.miniGame.coinToss.maxBettingPoint == null) {
+            throw StageException("CoinToss 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.miniGame.yavarwee.isActive && dto.miniGame.yavarwee.maxBettingPoint == null) {
+            throw StageException("Yavarwee 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.miniGame.plinko.isActive && dto.miniGame.plinko.maxBettingPoint == null) {
+            throw StageException("Plinko 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
@@ -23,6 +23,25 @@ data class CreateFastStageDto(
     val maintainer: List<Long>
 )
 
+data class CreateOfficialStageDto(
+    @NotBlank
+    val stageName: String,
+    @NotNull
+    val game: List<CreateStageGameDto>,
+    @NotNull
+    @Size(min = 1000, max = 100000)
+    val initialPoint: Long,
+    @NotNull
+    val rule: CreateStageRuleDto,
+    @NotNull
+    val miniGame: CreateOfficialStageMiniGameDto,
+    @NotNull
+    val shop: CreateStageShopDto,
+    val passCode: String?,
+    @NotNull
+    val maintainer: List<Long>
+)
+
 data class CreateStageGameDto(
     @NotNull
     val category: GameCategory,
@@ -42,9 +61,34 @@ data class CreateStageRuleDto(
     val minBettingPoint: Long,
 )
 
+data class CreateStageShopDto(
+    @NotNull
+    val coinToss: ShopInfoDto,
+    @NotNull
+    val yavarwee: ShopInfoDto,
+    @NotNull
+    val plinko: ShopInfoDto,
+)
+
 data class CreateFastStageMiniGameDto(
     @NotNull
     val coinToss: MiniGameInfoDto
+)
+
+data class CreateOfficialStageMiniGameDto(
+    @NotNull
+    val coinToss: MiniGameInfoDto,
+    @NotNull
+    val yavarwee: MiniGameInfoDto,
+    @NotNull
+    val plinko: MiniGameInfoDto
+)
+
+data class ShopInfoDto(
+    @NotNull
+    val isActive: Boolean,
+    val price: Long?,
+    val quantity: Int?,
 )
 
 data class MiniGameInfoDto(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
@@ -95,4 +95,5 @@ data class MiniGameInfoDto(
     @NotNull
     val isActive: Boolean,
     val maxBettingPoint: Long?,
+    val minBettingPoint: Long?,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.stage.root.application.listener
 
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
+import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
 import gogo.gogostage.global.kafka.publisher.StagePublisher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -19,6 +20,14 @@ class StageApplicationEventListener(
         with(event) {
             log.info("published create stage fast application event: {}", id)
             stagePublisher.publishCreateStageFastEVent(event)
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun createStageOfficial(event: CreateStageOfficialEvent) {
+        with(event) {
+            log.info("published create stage official application event: {}", id)
+            stagePublisher.publishCreateStageOfficialEVent(event)
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
@@ -8,9 +8,9 @@ data class CreateStageOfficialEvent(
 )
 
 data class OfficialStageMiniGameDto(
-    val isCoinTossActive: Boolean,
-    val isYavarweeActive: Boolean,
-    val isPlinkoActive: Boolean,
+    val coinToss: OfficialStageMiniGameInfoDto,
+    val yavarwee: OfficialStageMiniGameInfoDto,
+    val plinko: OfficialStageMiniGameInfoDto,
 )
 
 data class OfficialStageShopDto(
@@ -23,4 +23,9 @@ data class OfficialStageShopInfoDto(
     val isActive: Boolean,
     val price: Long?,
     val quantity: Int?,
+)
+data class OfficialStageMiniGameInfoDto(
+    val isActive: Boolean,
+    val maxBettingPoint: Long?,
+    val minBettingPoint: Long?,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
@@ -1,0 +1,14 @@
+package gogo.gogostage.domain.stage.root.event
+
+data class CreateStageOfficialEvent(
+    val id: String,
+    val stageId: Long,
+    val miniGame: OfficialStageMiniGameInfoDto,
+    val shop: OfficialStageMiniGameInfoDto
+)
+
+data class OfficialStageMiniGameInfoDto(
+    val isCoinTossActive: Boolean,
+    val isYavarweeActive: Boolean,
+    val isPlinkoActive: Boolean,
+)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
@@ -3,12 +3,24 @@ package gogo.gogostage.domain.stage.root.event
 data class CreateStageOfficialEvent(
     val id: String,
     val stageId: Long,
-    val miniGame: OfficialStageMiniGameInfoDto,
-    val shop: OfficialStageMiniGameInfoDto
+    val miniGame: OfficialStageMiniGameDto,
+    val shop: OfficialStageShopDto
 )
 
-data class OfficialStageMiniGameInfoDto(
+data class OfficialStageMiniGameDto(
     val isCoinTossActive: Boolean,
     val isYavarweeActive: Boolean,
     val isPlinkoActive: Boolean,
+)
+
+data class OfficialStageShopDto(
+    val coinToss: OfficialStageShopInfoDto,
+    val yavarwee: OfficialStageShopInfoDto,
+    val plinko: OfficialStageShopInfoDto,
+)
+
+data class OfficialStageShopInfoDto(
+    val isActive: Boolean,
+    val price: Long?,
+    val quantity: Int?,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.stage.root.persistence
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import jakarta.persistence.*
 import java.time.LocalDateTime
@@ -61,6 +62,19 @@ class Stage(
             participantCount = 0,
             isActiveMiniGame = isActiveMiniGame,
             isActiveShop = false,
+        )
+
+        fun officialOf(student: StudentByIdStub, dto: CreateOfficialStageDto, isActiveMiniGame: Boolean, isActiveShop: Boolean) = Stage(
+            schoolId = student.schoolId,
+            studentId = student.studentId,
+            type = StageType.OFFICIAL,
+            name = dto.stageName,
+            passCode = dto.passCode,
+            initialPoint = dto.initialPoint,
+            status = StageStatus.RECRUITING,
+            participantCount = 0,
+            isActiveMiniGame = isActiveMiniGame,
+            isActiveShop = isActiveShop,
         )
 
     }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/presentation/StageController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/presentation/StageController.kt
@@ -2,6 +2,7 @@ package gogo.gogostage.domain.stage.root.presentation
 
 import gogo.gogostage.domain.stage.root.application.StageService
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
+import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -21,6 +22,14 @@ class StageController(
         @RequestBody @Valid dto: CreateFastStageDto,
     ): ResponseEntity<Unit> {
         stageService.createFast(dto)
+        return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @PostMapping("/official")
+    fun createFast(
+        @RequestBody @Valid dto: CreateOfficialStageDto,
+    ): ResponseEntity<Unit> {
+        stageService.createOfficial(dto)
         return ResponseEntity.status(HttpStatus.CREATED).build()
     }
 

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
 
             // stage
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/fast").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/official").hasAnyRole(Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -48,7 +48,7 @@ class SecurityConfig(
 
             // stage
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/fast").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
-            httpRequests.requestMatchers(HttpMethod.POST, "/stage/official").hasAnyRole(Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/official").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -8,4 +8,5 @@ object KafkaTopics {
     const val BATCH_CANCEL = "batch_cancel"
     const val BATCH_CANCEL_DELETE_TEMP_POINT_FAILED = "batch_cancel_delete_temp_point_failed"
     const val CREATE_STAGE_FAST = "create_stage_fast"
+    const val CREATE_STAGE_OFFICIAL = "create_stage_official"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -1,12 +1,14 @@
 package gogo.gogostage.global.kafka.publisher
 
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
+import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_ADDITION_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.CREATE_STAGE_FAST
+import gogo.gogostage.global.kafka.properties.KafkaTopics.CREATE_STAGE_OFFICIAL
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
 import gogo.gogostage.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
@@ -56,6 +58,17 @@ class StagePublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = CREATE_STAGE_FAST,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishCreateStageOfficialEVent(
+        event: CreateStageOfficialEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = CREATE_STAGE_OFFICIAL,
             key = key,
             event = event
         )


### PR DESCRIPTION
## 개요
공식 스테이지 생성 API를 개발하였습니다.

## 본문
- STAFF(인증된 학교 관계자) 권한의 사용자만 요청을 보낼 수 있습니다.
- 스테이지 생성 요청시 스테이지를 저장 후 `stage_create_official` 토픽에 miniGame, shop 관련 정보가 담긴 이벤트를 발행합니다.
- `stage_create_official` 토픽에서 이벤트를 컨슘한 MiniGame, Shop 서비스는 해당 정보를 바탕으로 각각 미니게임, 상점을 생성합니다.