### PR TITLE
[community] 경기 게시판 검색 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.springframework.boot") version "3.4.1"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
+    kotlin("kapt") version "1.9.20"
 }
 
 group = "gogo"
@@ -40,6 +41,10 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    kapt("jakarta.annotation:jakarta.annotation-api")
+    kapt("jakarta.persistence:jakarta.persistence-api")
 }
 
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -1,9 +1,12 @@
 package gogo.gogostage.domain.community.root.application
 
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
-import gogo.gogostage.domain.community.root.persistence.Community
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
+
 import gogo.gogostage.domain.community.root.persistence.CommunityRepository
+import gogo.gogostage.domain.community.root.persistence.SortType
+import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.global.error.StageException
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 
@@ -16,6 +19,8 @@ class CommunityReader(
         communityRepository.findByStageId(stageId)
             ?: throw StageException("Stage Not Found, stageId=$stageId", HttpStatus.NOT_FOUND.value())
 
-    fun readBoards(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto) =
-        communityRepository.searchCommunityBoardPage(community, getCommunityBoardReqDto)
+    fun readBoards(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
+        val pageRequest = PageRequest.of(page, size)
+        return communityRepository.searchCommunityBoardPage(stageId, size, category, sort, pageRequest)
+    }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -1,5 +1,7 @@
 package gogo.gogostage.domain.community.root.application
 
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
+import gogo.gogostage.domain.community.root.persistence.Community
 import gogo.gogostage.domain.community.root.persistence.CommunityRepository
 import gogo.gogostage.global.error.StageException
 import org.springframework.http.HttpStatus
@@ -14,4 +16,6 @@ class CommunityReader(
         communityRepository.findByStageId(stageId)
             ?: throw StageException("Stage Not Found, stageId=$stageId", HttpStatus.NOT_FOUND.value())
 
+    fun readBoards(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto) =
+        communityRepository.searchCommunityBoardPage(community, getCommunityBoardReqDto)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
@@ -1,7 +1,11 @@
 package gogo.gogostage.domain.community.root.application
 
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import org.springframework.data.domain.Page
 
 interface CommunityService {
     fun writeCommunityBoard(stageId: Long, writeCommunityBoardDto: WriteCommunityBoardDto)
+    fun getStageBoard(stageId: Long, getCommunityBoardDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto>
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
@@ -1,11 +1,11 @@
 package gogo.gogostage.domain.community.root.application
 
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
-import org.springframework.data.domain.Page
+import gogo.gogostage.domain.community.root.persistence.SortType
+import gogo.gogostage.domain.game.persistence.GameCategory
 
 interface CommunityService {
     fun writeCommunityBoard(stageId: Long, writeCommunityBoardDto: WriteCommunityBoardDto)
-    fun getStageBoard(stageId: Long, getCommunityBoardDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto>
+    fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -13,7 +13,8 @@ import org.springframework.transaction.annotation.Transactional
 class CommunityServiceImpl(
     private val communityReader: CommunityReader,
     private val boardProcessor: BoardProcessor,
-    private val userUtil: UserContextUtil
+    private val userUtil: UserContextUtil,
+    private val communityValidator: CommunityValidator
 ): CommunityService {
 
     @Transactional
@@ -27,6 +28,7 @@ class CommunityServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
+        communityValidator.validPageAndSize(page, size)
         return communityReader.readBoards(stageId, page, size, category, sort)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -1,11 +1,11 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardProcessor
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import gogo.gogostage.domain.community.root.persistence.SortType
+import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.global.util.UserContextUtil
-import org.springframework.data.domain.Page
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -26,9 +26,8 @@ class CommunityServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getStageBoard(stageId: Long, getCommunityBoardDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto> {
-        val community = communityReader.readByStageId(stageId)
-        return communityReader.readBoards(community, getCommunityBoardDto)
+    override fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
+        return communityReader.readBoards(stageId, page, size, category, sort)
     }
 
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -1,8 +1,11 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardProcessor
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
 import gogo.gogostage.global.util.UserContextUtil
+import org.springframework.data.domain.Page
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,4 +24,12 @@ class CommunityServiceImpl(
 
         // 추후 욕설 필터링 요청 처리 필요
     }
+
+    @Transactional(readOnly = true)
+    override fun getStageBoard(stageId: Long, getCommunityBoardDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto> {
+        val community = communityReader.readByStageId(stageId)
+        return communityReader.readBoards(community, getCommunityBoardDto)
+    }
+
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityValidator.kt
@@ -1,0 +1,16 @@
+package gogo.gogostage.domain.community.root.application
+
+import gogo.gogostage.global.error.StageException
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class CommunityValidator {
+
+    fun validPageAndSize(page: Int, size: Int) {
+        if (page < 0 || size < 0) {
+            throw StageException("page와 size는 음수일 수 없습니다.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -1,7 +1,11 @@
 package gogo.gogostage.domain.community.root.application.dto
 
+import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
+import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.stage.root.persistence.StageType
 import org.jetbrains.annotations.NotNull
+import java.time.LocalDateTime
 
 data class WriteCommunityBoardDto(
     @NotNull
@@ -10,4 +14,40 @@ data class WriteCommunityBoardDto(
     val content: String,
     @NotNull
     val gameCategory: GameCategory
+)
+
+data class GetCommunityBoardReqDto(
+    val page: Int,
+    val size: Int,
+    val gameCategory: GameCategory,
+    val sort: SortType
+)
+
+data class GetCommunityBoardResDto(
+    val info: InfoDto,
+    val board: List<BoardDto>
+)
+
+data class InfoDto(
+    val totalPage: Int,
+    val totalElement: Int
+)
+
+data class BoardDto(
+    val boardId: Long,
+    val studentId: Long,
+    val gameType: GameSystem,
+    val title: String,
+    val likeCount: Int,
+    val createdAt: LocalDateTime,
+    val isFiltered: Boolean,
+    val stageType: StageType,
+    val author: AuthorDto
+)
+
+data class AuthorDto(
+    val studentId: Long,
+    val name: String,
+    val classNumber: Int,
+    val studentNumber: Int
 )

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -19,7 +19,7 @@ data class WriteCommunityBoardDto(
 data class GetCommunityBoardReqDto(
     val page: Int,
     val size: Int,
-    val gameCategory: GameCategory,
+    val category: GameCategory,
     val sort: SortType
 )
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -1,8 +1,6 @@
 package gogo.gogostage.domain.community.root.application.dto
 
-import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
-import gogo.gogostage.domain.game.persistence.GameSystem
 import gogo.gogostage.domain.stage.root.persistence.StageType
 import org.jetbrains.annotations.NotNull
 import java.time.LocalDateTime
@@ -14,13 +12,6 @@ data class WriteCommunityBoardDto(
     val content: String,
     @NotNull
     val gameCategory: GameCategory
-)
-
-data class GetCommunityBoardReqDto(
-    val page: Int,
-    val size: Int,
-    val category: GameCategory,
-    val sort: SortType
 )
 
 data class GetCommunityBoardResDto(
@@ -36,11 +27,10 @@ data class InfoDto(
 data class BoardDto(
     val boardId: Long,
     val studentId: Long,
-    val gameType: GameSystem,
+    val gameCategory: GameCategory,
     val title: String,
     val likeCount: Int,
     val createdAt: LocalDateTime,
-    val isFiltered: Boolean,
     val stageType: StageType,
     val author: AuthorDto
 )

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/Community.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/Community.kt
@@ -20,3 +20,7 @@ class Community(
     @Column(name = "category", nullable = false)
     val category: GameCategory
 )
+
+enum class SortType {
+    LAST, LATEST
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -1,0 +1,9 @@
+package gogo.gogostage.domain.community.root.persistence
+
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
+import org.springframework.data.domain.Page
+
+interface CommunityCustomRepository {
+    fun searchCommunityBoardPage(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto>
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -1,9 +1,9 @@
 package gogo.gogostage.domain.community.root.persistence
 
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
-import org.springframework.data.domain.Page
+import gogo.gogostage.domain.game.persistence.GameCategory
+import org.springframework.data.domain.Pageable
 
 interface CommunityCustomRepository {
-    fun searchCommunityBoardPage(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto>
+    fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -21,7 +21,7 @@ class CommunityCustomRepositoryImpl(
 
     override fun searchCommunityBoardPage(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto> {
         val boards = queryFactory.select(
-            Projections.constructor(
+            Projections.fields(
                 BoardDto::class.java,
                 board.id,
                 board.studentId,
@@ -35,6 +35,9 @@ class CommunityCustomRepositoryImpl(
             .from(board)
             .join(stage).on(QCommunity.community.stage.id.eq(community.stage.id))
             .join(game).on(stage.id.eq(game.stage.id))
+            .where(
+                QCommunity.community.category.eq(getCommunityBoardReqDto.category)
+            )
             .orderBy(
                 when(getCommunityBoardReqDto.sort) {
                     SortType.LAST -> board.createdAt.asc()

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -1,0 +1,85 @@
+package gogo.gogostage.domain.community.root.persistence
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import gogo.gogostage.domain.community.board.persistence.QBoard.board
+import gogo.gogostage.domain.community.root.application.dto.*
+import gogo.gogostage.domain.game.persistence.QGame.game
+import gogo.gogostage.domain.stage.root.persistence.QStage.stage
+import gogo.gogostage.global.internal.student.api.StudentApi
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+import org.springframework.stereotype.Repository
+
+@Repository
+class CommunityCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val studentApi: StudentApi
+): CommunityCustomRepository {
+
+    override fun searchCommunityBoardPage(community: Community, getCommunityBoardReqDto: GetCommunityBoardReqDto): Page<GetCommunityBoardResDto> {
+        val boards = queryFactory.select(
+            Projections.constructor(
+                BoardDto::class.java,
+                board.id,
+                board.studentId,
+                game.system,
+                board.title,
+                board.likeCount,
+                board.createdAt,
+                board.isFiltered,
+                stage.type
+            ))
+            .from(board)
+            .join(stage).on(QCommunity.community.stage.id.eq(community.stage.id))
+            .join(game).on(stage.id.eq(game.stage.id))
+            .orderBy(
+                when(getCommunityBoardReqDto.sort) {
+                    SortType.LAST -> board.createdAt.asc()
+                    SortType.LATEST -> board.createdAt.desc()
+                }
+            )
+
+            .offset((getCommunityBoardReqDto.page.toLong() - 1) * getCommunityBoardReqDto.size.toLong())
+            .limit(getCommunityBoardReqDto.size.toLong())
+            .fetch()
+
+        val studentIds = queryFactory
+            .select(board.studentId)
+            .from(board)
+            .fetch()
+
+        val communityStudents = studentApi.queryByStudentsIds(studentIds)
+
+        val boardDtoList = boards.map { board ->
+            val author = communityStudents.find { it.studentId == board.studentId }?.let {
+                AuthorDto(it.studentId, it.name, it.classNumber, it.studentNumber)
+            }
+
+            board.copy(author = author!!)
+        }
+
+        val totalElement = queryFactory
+            .select(board.count())
+            .from(board)
+            .where(board.community.id.eq(community.id))
+            .fetchOne()
+            ?: 0L
+
+        val totalPage = if (totalElement.toInt() % getCommunityBoardReqDto.size == 0) {
+            totalElement.toInt() / getCommunityBoardReqDto.size
+        } else {
+            totalElement.toInt() / getCommunityBoardReqDto.size + 1
+        }
+
+        val infoDto = InfoDto(totalPage, totalElement.toInt())
+
+        val getCommunityBoardResDtoList = listOf(GetCommunityBoardResDto(infoDto, boardDtoList))
+
+        val pageable = PageRequest.of(getCommunityBoardReqDto.page, getCommunityBoardReqDto.size)
+
+        return PageImpl(getCommunityBoardResDtoList, pageable, totalElement)
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -75,20 +75,15 @@ class CommunityCustomRepositoryImpl(
             )
         }.toList()
 
-        val totalElement = queryFactory
-            .select(board.count())
-            .from(board)
-            .where(board.community.id.eq(community.id))
-            .fetchOne()
-            ?: 0L
+        val totalElement = boardDtoList.size
 
-        val totalPage = if (totalElement.toInt() % size == 0) {
-            totalElement.toInt() / size
+        val totalPage = if (totalElement % size == 0) {
+            totalElement / size
         } else {
-            totalElement.toInt() / size + 1
+            totalElement / size + 1
         }
 
-        val infoDto = InfoDto(totalPage, totalElement.toInt())
+        val infoDto = InfoDto(totalPage, totalElement)
 
         return GetCommunityBoardResDto(infoDto, boardDtoList)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityRepository.kt
@@ -2,6 +2,6 @@ package gogo.gogostage.domain.community.root.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CommunityRepository: JpaRepository<Community, Long> {
+interface CommunityRepository: JpaRepository<Community, Long>, CommunityCustomRepository {
     fun findByStageId(stageId: Long): Community?
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -1,19 +1,19 @@
 package gogo.gogostage.domain.community.root.presentation
 
 import gogo.gogostage.domain.community.root.application.CommunityService
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import gogo.gogostage.domain.community.root.persistence.SortType
+import gogo.gogostage.domain.game.persistence.GameCategory
 import jakarta.validation.Valid
-import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -34,9 +34,13 @@ class CommunityController(
     @GetMapping("/{stage_id}")
     fun getStageBoard(
         @PathVariable("stage_id") stageId: Long,
-        @ModelAttribute getCommunityBoardDto: GetCommunityBoardReqDto
-    ): ResponseEntity<Page<GetCommunityBoardResDto>> {
-        val response = communityService.getStageBoard(stageId, getCommunityBoardDto)
+        @RequestParam(required = false, defaultValue = "0") page: Int,
+        @RequestParam(required = false, defaultValue = "20") size: Int,
+        @RequestParam(required = false) category: GameCategory? = null,
+        @RequestParam(required = false) sort: SortType = SortType.LATEST
+    ): ResponseEntity<GetCommunityBoardResDto> {
+        val response = communityService.getStageBoard(
+            stageId, page, size, category, sort)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -1,10 +1,15 @@
 package gogo.gogostage.domain.community.root.presentation
 
 import gogo.gogostage.domain.community.root.application.CommunityService
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardReqDto
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,5 +29,14 @@ class CommunityController(
     ): ResponseEntity<Void> {
         communityService.writeCommunityBoard(stageId, writeCommunityBoardDto)
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping("/{stage_id}")
+    fun getStageBoard(
+        @PathVariable("stage_id") stageId: Long,
+        @ModelAttribute getCommunityBoardDto: GetCommunityBoardReqDto
+    ): ResponseEntity<Page<GetCommunityBoardResDto>> {
+        val response = communityService.getStageBoard(stageId, getCommunityBoardDto)
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package gogo.gogostage.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig(
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
 
             // community
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()

--- a/src/main/kotlin/gogo/gogostage/global/feign/client/StudentClient.kt
+++ b/src/main/kotlin/gogo/gogostage/global/feign/client/StudentClient.kt
@@ -16,5 +16,5 @@ interface StudentClient {
     @GetMapping("/user/student/bundle")
     fun queryCommunityStudentsByStudentId(
         @RequestParam("studentIds") ids: List<Long>
-    ): List<StudentByIdsStub>
+    ): StudentByIdsStub
 }

--- a/src/main/kotlin/gogo/gogostage/global/feign/client/StudentClient.kt
+++ b/src/main/kotlin/gogo/gogostage/global/feign/client/StudentClient.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.global.feign.client
 
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
+import gogo.gogostage.global.internal.student.stub.StudentByIdsStub
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -11,4 +12,9 @@ interface StudentClient {
     fun queryStudentByUserId(
         @RequestParam("userId") userId: Long
     ): StudentByIdStub
+
+    @GetMapping("/user/student/bundle")
+    fun queryCommunityStudentsByStudentId(
+        @RequestParam("studentIds") ids: List<Long>
+    ): List<StudentByIdsStub>
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApi.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApi.kt
@@ -5,5 +5,5 @@ import gogo.gogostage.global.internal.student.stub.StudentByIdsStub
 
 interface StudentApi {
     fun queryByUserId(userId: Long): StudentByIdStub
-    fun queryByStudentsIds(studentIds: List<Long>): List<StudentByIdsStub>
+    fun queryByStudentsIds(studentIds: List<Long>): StudentByIdsStub
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApi.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApi.kt
@@ -1,7 +1,9 @@
 package gogo.gogostage.global.internal.student.api
 
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
+import gogo.gogostage.global.internal.student.stub.StudentByIdsStub
 
 interface StudentApi {
     fun queryByUserId(userId: Long): StudentByIdStub
+    fun queryByStudentsIds(studentIds: List<Long>): List<StudentByIdsStub>
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApiImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApiImpl.kt
@@ -2,6 +2,7 @@ package gogo.gogostage.global.internal.student.api
 
 import gogo.gogostage.global.feign.client.StudentClient
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
+import gogo.gogostage.global.internal.student.stub.StudentByIdsStub
 import org.springframework.stereotype.Component
 
 @Component
@@ -10,5 +11,9 @@ class StudentApiImpl(
 ) : StudentApi {
     override fun queryByUserId(userId: Long): StudentByIdStub {
         return studentClient.queryStudentByUserId(userId)
+    }
+
+    override fun queryByStudentsIds(studentIds: List<Long>): List<StudentByIdsStub> {
+        return studentClient.queryCommunityStudentsByStudentId(studentIds)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApiImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/api/StudentApiImpl.kt
@@ -13,7 +13,7 @@ class StudentApiImpl(
         return studentClient.queryStudentByUserId(userId)
     }
 
-    override fun queryByStudentsIds(studentIds: List<Long>): List<StudentByIdsStub> {
+    override fun queryByStudentsIds(studentIds: List<Long>): StudentByIdsStub {
         return studentClient.queryCommunityStudentsByStudentId(studentIds)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/stub/StudentStub.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/stub/StudentStub.kt
@@ -16,3 +16,13 @@ data class StudentByIdStub(
     val isActiveProfanityFilter: Boolean,
     val createdAt: LocalDateTime
 )
+
+data class StudentByIdsStub(
+    val studentId: Long,
+    val schoolId: Long,
+    val name: String,
+    val deviceToken: String?,
+    val sex: Sex,
+    val classNumber: Int,
+    val studentNumber: Int
+)

--- a/src/main/kotlin/gogo/gogostage/global/internal/student/stub/StudentStub.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/student/stub/StudentStub.kt
@@ -18,11 +18,15 @@ data class StudentByIdStub(
 )
 
 data class StudentByIdsStub(
+    val students: List<StudentByIdsStubDto>
+)
+
+data class StudentByIdsStubDto(
     val studentId: Long,
     val schoolId: Long,
+    val sex: Sex,
     val name: String,
     val deviceToken: String?,
-    val sex: Sex,
     val classNumber: Int,
-    val studentNumber: Int
+    val studentNumber: Int,
 )


### PR DESCRIPTION
# 개요
경기 게시판 조회 API를 개발하였습니다.

# 본문
* page, size, gameType, sortType을 QueryString을 받고 stageId를 Path를 입력하여 요청을 받는다.
* stageId를 가지고 Community를 조회 후 QuertString으로 받은 값을 바탕으로 queryDsl을 사용하여 반환한다.