### PR TITLE
[stage] Shop 서비스 티켓 구매 이벤트 핸들링

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -44,7 +44,7 @@ class ParticipateProcessor(
             stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(event.stageId, event.studentId)
                 ?: throw StageException("Stage Participant Not Found, Stage id = ${event.stageId}, Student id = ${event.studentId}", HttpStatus.NOT_FOUND.value())
 
-        val totalPrice = event.ticketPrice.toLong() * event.purchaseQuantity.toLong()
+        val totalPrice = event.ticketPrice * event.purchaseQuantity.toLong()
 
         stageParticipant.minusPoint(totalPrice)
         stageParticipantRepository.save(stageParticipant)
@@ -56,6 +56,7 @@ class ParticipateProcessor(
                 studentId = event.studentId,
                 shopMiniGameId = event.shopMiniGameId,
                 ticketType = event.ticketType,
+                ticketPrice = event.ticketPrice,
                 purchaseQuantity = event.purchaseQuantity,
             )
         )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -2,17 +2,22 @@ package gogo.gogostage.domain.stage.participant.root.application
 
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
+import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
 import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.kafka.consumer.dto.TicketShopBuyEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.util.*
 
 @Component
 class ParticipateProcessor(
     private val matchRepository: MatchRepository,
-    private val stageParticipantRepository: StageParticipantRepository
+    private val stageParticipantRepository: StageParticipantRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) {
 
     @Transactional
@@ -31,6 +36,29 @@ class ParticipateProcessor(
 
         stageParticipantRepository.save(stageParticipant)
         matchRepository.save(match)
+    }
+
+    @Transactional
+    fun buyTicket(event: TicketShopBuyEvent) {
+        val stageParticipant =
+            stageParticipantRepository.queryStageParticipantByStageIdAndStudentId(event.stageId, event.studentId)
+                ?: throw StageException("Stage Participant Not Found, Stage id = ${event.stageId}, Student id = ${event.studentId}", HttpStatus.NOT_FOUND.value())
+
+        val totalPrice = event.ticketPrice.toLong() * event.purchaseQuantity.toLong()
+
+        stageParticipant.minusPoint(totalPrice)
+        stageParticipantRepository.save(stageParticipant)
+
+        applicationEventPublisher.publishEvent(
+            TicketPointMinusEvent(
+                id = UUID.randomUUID().toString(),
+                stageId = event.stageId,
+                studentId = event.studentId,
+                shopMiniGameId = event.shopMiniGameId,
+                ticketType = event.ticketType,
+                purchaseQuantity = event.purchaseQuantity,
+            )
+        )
     }
 
     private fun updateMatchBettingPointTeam(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/listener/StageParticipantApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/listener/StageParticipantApplicationEventListener.kt
@@ -1,0 +1,25 @@
+package gogo.gogostage.domain.stage.participant.root.application.listener
+
+import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
+import gogo.gogostage.global.kafka.publisher.StagePublisher
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class StageParticipantApplicationEventListener(
+    private val stagePublisher: StagePublisher
+) {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun createStageFast(event: TicketPointMinusEvent) {
+        with(event) {
+            log.info("published ticket point minus application event: {}", id)
+            stagePublisher.publishTicketPointMinusEvent(event)
+        }
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/event/TicketPointMinusEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/event/TicketPointMinusEvent.kt
@@ -1,0 +1,12 @@
+package gogo.gogostage.domain.stage.participant.root.event
+
+import gogo.gogostage.global.kafka.consumer.dto.TicketType
+
+data class TicketPointMinusEvent(
+    val id: String,
+    val stageId: Long,
+    val studentId: Long,
+    val shopMiniGameId: Long,
+    val ticketType: TicketType,
+    val purchaseQuantity: Int
+)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/event/TicketPointMinusEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/event/TicketPointMinusEvent.kt
@@ -8,5 +8,6 @@ data class TicketPointMinusEvent(
     val studentId: Long,
     val shopMiniGameId: Long,
     val ticketType: TicketType,
+    val ticketPrice: Long,
     val purchaseQuantity: Int
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
@@ -19,7 +19,7 @@ class StageApplicationEventListener(
     fun createStageFast(event: CreateStageFastEvent) {
         with(event) {
             log.info("published create stage fast application event: {}", id)
-            stagePublisher.publishCreateStageFastEVent(event)
+            stagePublisher.publishCreateStageFastEvent(event)
         }
     }
 
@@ -27,7 +27,7 @@ class StageApplicationEventListener(
     fun createStageOfficial(event: CreateStageOfficialEvent) {
         with(event) {
             log.info("published create stage official application event: {}", id)
-            stagePublisher.publishCreateStageOfficialEVent(event)
+            stagePublisher.publishCreateStageOfficialEvent(event)
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -1,9 +1,6 @@
 package gogo.gogostage.global.kafka.configuration
 
-import gogo.gogostage.global.kafka.consumer.BatchCancelConsumer
-import gogo.gogostage.global.kafka.consumer.MatchBatchConsumer
-import gogo.gogostage.global.kafka.consumer.MatchBettingConsumer
-import gogo.gogostage.global.kafka.consumer.TicketShopBuyConsumer
+import gogo.gogostage.global.kafka.consumer.*
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,6 +15,10 @@ import org.springframework.kafka.listener.AcknowledgingMessageListener
 class KafkaConsumerConfig(
     private val kafkaProperties: KafkaProperties
 ) {
+
+    @Bean
+    fun ticketAdditionFailedEventListenerContainerFactory(listener: TicketAdditionFailedConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
 
     @Bean
     fun ticketShopBuyEventListenerContainerFactory(listener: TicketShopBuyConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =

--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -3,6 +3,7 @@ package gogo.gogostage.global.kafka.configuration
 import gogo.gogostage.global.kafka.consumer.BatchCancelConsumer
 import gogo.gogostage.global.kafka.consumer.MatchBatchConsumer
 import gogo.gogostage.global.kafka.consumer.MatchBettingConsumer
+import gogo.gogostage.global.kafka.consumer.TicketShopBuyConsumer
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -17,6 +18,10 @@ import org.springframework.kafka.listener.AcknowledgingMessageListener
 class KafkaConsumerConfig(
     private val kafkaProperties: KafkaProperties
 ) {
+
+    @Bean
+    fun ticketShopBuyEventListenerContainerFactory(listener: TicketShopBuyConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
 
     @Bean
     fun matchBettingEventListenerContainerFactory(listener: MatchBettingConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/TicketAdditionFailedConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/TicketAdditionFailedConsumer.kt
@@ -1,0 +1,40 @@
+package gogo.gogostage.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.stage.participant.root.application.ParticipateProcessor
+import gogo.gogostage.global.kafka.consumer.dto.*
+import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_ADDITION_FAILED
+import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_SHOP_BUY
+import gogo.gogostage.global.kafka.publisher.StagePublisher
+import gogo.gogostage.global.saga.TicketAdditionFailedSaga
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class TicketAdditionFailedConsumer(
+    private val objectMapper: ObjectMapper,
+    private val ticketAdditionFailedSaga: TicketAdditionFailedSaga
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [TICKET_ADDITION_FAILED],
+        groupId = "gogo",
+        containerFactory = "ticketAdditionFailedEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), TicketAdditionFailedEvent::class.java)
+        log.info("${TICKET_ADDITION_FAILED}_topic, key: $key, event: $event")
+
+        ticketAdditionFailedSaga.rollbackPoint(event)
+
+        acknowledgment!!.acknowledge()
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/TicketShopBuyConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/TicketShopBuyConsumer.kt
@@ -1,0 +1,57 @@
+package gogo.gogostage.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.stage.participant.root.application.ParticipateProcessor
+import gogo.gogostage.global.kafka.consumer.dto.*
+import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_SHOP_BUY
+import gogo.gogostage.global.kafka.publisher.StagePublisher
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class TicketShopBuyConsumer(
+    private val objectMapper: ObjectMapper,
+    private val stageParticipateProcessor: ParticipateProcessor,
+    private val stagePublisher: StagePublisher
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [TICKET_SHOP_BUY],
+        groupId = "gogo",
+        containerFactory = "ticketShopBuyEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), TicketShopBuyEvent::class.java)
+        log.info("${TICKET_SHOP_BUY}_topic, key: $key, event: $event")
+
+        try {
+
+            stageParticipateProcessor.buyTicket(event)
+
+        } catch (e: Exception) {
+
+            log.error("Failed to Ticket Shop Buy, Shop Receipt Id = ${event.shopReceiptId}", e)
+
+            stagePublisher.publishTicketPointMinusFailedEvent(
+                event = TicketPointMinusFailedEvent(
+                    id = UUID.randomUUID().toString(),
+                    stageId = event.stageId,
+                    shopMiniGameId = event.shopMiniGameId,
+                    ticketType = event.ticketType,
+                    shopReceiptId = event.shopReceiptId,
+                )
+            )
+
+        }
+
+        acknowledgment!!.acknowledge()
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketAdditionFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketAdditionFailedEvent.kt
@@ -1,17 +1,12 @@
 package gogo.gogostage.global.kafka.consumer.dto
 
-data class TicketShopBuyEvent(
+data class TicketAdditionFailedEvent(
     val id: String,
-    val stageId: Long,
     val studentId: Long,
-    val shopId: Long,
+    val stageId: Long,
     val shopMiniGameId: Long,
     val ticketType: TicketType,
     val shopReceiptId: Long,
     val ticketPrice: Long,
-    val purchaseQuantity: Int,
+    val purchaseQuantity: Int
 )
-
-enum class TicketType {
-    COINTOSS, YAVARWEE, PLINKO
-}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketPointMinusFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketPointMinusFailedEvent.kt
@@ -1,0 +1,9 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class TicketPointMinusFailedEvent(
+    val id: String,
+    val stageId: Long,
+    val shopMiniGameId: Long,
+    val ticketType: TicketType,
+    val shopReceiptId: Long
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketShopBuyEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/TicketShopBuyEvent.kt
@@ -1,0 +1,17 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class TicketShopBuyEvent(
+    val id: String,
+    val stageId: Long,
+    val studentId: Long,
+    val shopId: Long,
+    val shopMiniGameId: Long,
+    val ticketType: TicketType,
+    val shopReceiptId: Long,
+    val ticketPrice: Int,
+    val purchaseQuantity: Int,
+)
+
+enum class TicketType {
+    COINTOSS, YAVARWEE, PLINKO
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -9,4 +9,8 @@ object KafkaTopics {
     const val BATCH_CANCEL_DELETE_TEMP_POINT_FAILED = "batch_cancel_delete_temp_point_failed"
     const val CREATE_STAGE_FAST = "create_stage_fast"
     const val CREATE_STAGE_OFFICIAL = "create_stage_official"
+    const val TICKET_SHOP_BUY = "ticket_shop_buy"
+    const val TICKET_POINT_MINUS = "ticket_point_minus"
+    const val TICKET_POINT_MINUS_FAILED = "ticket_point_minus_failed"
+    const val TICKET_ADDITION_FAILED = "ticket_addition_failed"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -1,15 +1,19 @@
 package gogo.gogostage.global.kafka.publisher
 
+import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
+import gogo.gogostage.global.kafka.consumer.dto.TicketPointMinusFailedEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_ADDITION_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.CREATE_STAGE_FAST
 import gogo.gogostage.global.kafka.properties.KafkaTopics.CREATE_STAGE_OFFICIAL
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
+import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS
+import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS_FAILED
 import gogo.gogostage.global.publisher.TransactionEventPublisher
 import org.springframework.stereotype.Component
 import java.util.*
@@ -52,7 +56,7 @@ class StagePublisher(
         )
     }
 
-    fun publishCreateStageFastEVent(
+    fun publishCreateStageFastEvent(
         event: CreateStageFastEvent
     ) {
         val key = UUID.randomUUID().toString()
@@ -63,12 +67,34 @@ class StagePublisher(
         )
     }
 
-    fun publishCreateStageOfficialEVent(
+    fun publishCreateStageOfficialEvent(
         event: CreateStageOfficialEvent
     ) {
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = CREATE_STAGE_OFFICIAL,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishTicketPointMinusEvent(
+        event: TicketPointMinusEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = TICKET_POINT_MINUS,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishTicketPointMinusFailedEvent(
+        event: TicketPointMinusFailedEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = TICKET_POINT_MINUS_FAILED,
             key = key,
             event = event
         )

--- a/src/main/kotlin/gogo/gogostage/global/saga/TicketAdditionFailedSaga.kt
+++ b/src/main/kotlin/gogo/gogostage/global/saga/TicketAdditionFailedSaga.kt
@@ -1,0 +1,23 @@
+package gogo.gogostage.global.saga
+
+import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
+import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.kafka.consumer.dto.TicketAdditionFailedEvent
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TicketAdditionFailedSaga(private val stageParticipantRepository: StageParticipantRepository) {
+
+    @Transactional
+    fun rollbackPoint(event: TicketAdditionFailedEvent) {
+        val stageParticipant =
+            stageParticipantRepository .queryStageParticipantByStageIdAndStudentId(event.stageId, event.studentId)
+                ?: throw StageException("Stage Participant Not Found -- SAGA.rollbackPoint(stageId = ${event.stageId}, studentId = ${event.studentId})", HttpStatus.NOT_FOUND.value())
+
+        val totalPrice = event.ticketPrice * event.purchaseQuantity.toLong()
+        stageParticipant.plusPoint(totalPrice)
+    }
+
+}


### PR DESCRIPTION
## 개요
Shop 서비스에서 티켓 구매시 이벤트 핸들링을 처리했습니다.

## 본문
- `ticket_shop_buy`: 해당 이벤트를 컨슘하여 구매 금액 만큼의 포인트를 차감합니다.
  - V -> `ticket_point_minus`: 해당 이벤트를 발행합니다. MiniGame 서비스에서 컨슘하여 타켓 수량을 추가합니다.
  - X -> `ticket_point_minus_failed`: 포인트 차감 중 예외 발생시 해당 이벤트를 발행하여 Shop 서비스에서 롤백 처리를 기대합니다.
- `ticket_addition_failed`: 해당 이벤트를 컨슘하여 포인트를 롤백합니다. (MiniGame 서비스에서 티켓 수량 추가 실패시 발행됨)