### PR TITLE
[community] 경기 게시글 상세보기 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLikeRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLikeRepository.kt
@@ -1,0 +1,7 @@
+package gogo.gogostage.domain.community.boardlike.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BoardLikeRepository: JpaRepository<BoardLike, Long> {
+    fun existsByStudentIdAndBoardId(studentId: Long, boardId: Long): Boolean
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
@@ -26,5 +26,8 @@ class Comment(
     val isFiltered: Boolean,
 
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+
+    @Column(name = "like_count", nullable = false)
+    val likeCount: Int,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
@@ -19,8 +19,8 @@ class Comment(
     @Column(name = "student_id", nullable = false)
     val studentId: Long,
 
-    @Column(name = "comment", nullable = false)
-    val comment: String,
+    @Column(name = "content", nullable = false)
+    val content: String,
 
     @Column(name = "is_filtered", nullable = false)
     val isFiltered: Boolean,

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.community.root.application
 
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 
 import gogo.gogostage.domain.community.root.persistence.CommunityRepository
@@ -23,4 +24,7 @@ class CommunityReader(
         val pageRequest = PageRequest.of(page, size)
         return communityRepository.searchCommunityBoardPage(stageId, size, category, sort, pageRequest)
     }
+
+    fun readBoardInfo(boardId: Long): GetCommunityBoardInfoResDto =
+        communityRepository.getCommunityBoardInfo(boardId)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.community.root.application
 
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
 import gogo.gogostage.domain.community.root.persistence.SortType
@@ -8,4 +9,5 @@ import gogo.gogostage.domain.game.persistence.GameCategory
 interface CommunityService {
     fun writeCommunityBoard(stageId: Long, writeCommunityBoardDto: WriteCommunityBoardDto)
     fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto
+    fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardProcessor
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
 import gogo.gogostage.domain.community.root.persistence.SortType
@@ -28,6 +29,11 @@ class CommunityServiceImpl(
     @Transactional(readOnly = true)
     override fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
         return communityReader.readBoards(stageId, page, size, category, sort)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto {
+        return communityReader.readBoardInfo(boardId)
     }
 
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.community.root.application.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.stage.root.persistence.StageType
 import org.jetbrains.annotations.NotNull
@@ -30,6 +31,7 @@ data class BoardDto(
     val gameCategory: GameCategory,
     val title: String,
     val likeCount: Int,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val createdAt: LocalDateTime,
     val stageType: StageType,
     val author: AuthorDto
@@ -40,4 +42,34 @@ data class AuthorDto(
     val name: String,
     val classNumber: Int,
     val studentNumber: Int
+)
+
+data class GetCommunityBoardInfoResDto(
+    val boardId: Long,
+    val title: String,
+    val content: String,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val createdAt: LocalDateTime,
+    val stage: StageDto,
+    val author: AuthorDto,
+    val commentCount: Int,
+    val comment: List<CommentDto>
+
+)
+
+data class StageDto(
+    val name: String,
+    val category: GameCategory
+)
+
+data class CommentDto(
+    val commentId: Long,
+    val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val createdAt: LocalDateTime,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    val author: AuthorDto
 )

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -1,9 +1,11 @@
 package gogo.gogostage.domain.community.root.persistence
 
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.game.persistence.GameCategory
 import org.springframework.data.domain.Pageable
 
 interface CommunityCustomRepository {
     fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
+    fun getCommunityBoardInfo(boardId: Long): GetCommunityBoardInfoResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -4,19 +4,28 @@ import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import gogo.gogostage.domain.community.board.persistence.BoardRepository
 import gogo.gogostage.domain.community.board.persistence.QBoard.board
+import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
+import gogo.gogostage.domain.community.comment.persistence.QComment.comment
+import gogo.gogostage.domain.community.commentlike.persistence.QCommentLike.commentLike
 import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.QCommunity.community
 import gogo.gogostage.domain.game.persistence.GameCategory
+import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.api.StudentApi
 import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 
 import org.springframework.stereotype.Repository
 
 @Repository
 class CommunityCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
-    private val studentApi: StudentApi
+    private val studentApi: StudentApi,
+    private val boardRepository: BoardRepository,
+    private val boardLikeRepository: BoardLikeRepository
 ): CommunityCustomRepository {
 
     override fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto {
@@ -91,5 +100,80 @@ class CommunityCustomRepositoryImpl(
         val infoDto = InfoDto(totalPage, totalElement.toInt())
 
         return GetCommunityBoardResDto(infoDto, boardDtoList)
+    }
+
+    override fun getCommunityBoardInfo(boardId: Long): GetCommunityBoardInfoResDto {
+        val queryBoard = boardRepository.findByIdOrNull(boardId)
+            ?: throw StageException("Board Not Found, boardId = $boardId", HttpStatus.NOT_FOUND.value())
+
+        val stageDto = StageDto(queryBoard.community.stage.name, queryBoard.community.category)
+
+        val boardAuthorStudentIdList = listOf(queryBoard.studentId)
+
+        val boardAuthor = studentApi.queryByStudentsIds(boardAuthorStudentIdList).students
+
+        val boardAuthorDto = boardAuthor.map { student ->
+            AuthorDto(student.studentId, student.name, student.classNumber, student.studentNumber)
+        }
+
+        val boardAuthorStudentId = boardAuthorDto.get(0).studentId
+
+        val isAuthorBoardLike = boardLikeRepository.existsByStudentIdAndBoardId(boardAuthorStudentId, queryBoard.id)
+
+        val predicate = BooleanBuilder()
+
+        predicate.and(board.id.eq(comment.board.id))
+
+        val comments = queryFactory.selectFrom(comment)
+            .where(predicate)
+            .fetch()
+
+        val studentIds = queryFactory.select(comment.studentId)
+            .from(comment)
+            .where(comment.board.id.eq(boardId))
+            .fetch()
+
+        val commentLikeIds = queryFactory.select(commentLike.id)
+            .from(commentLike)
+            .where(commentLike.comment.board.id.eq(boardId).and(
+                commentLike.studentId.eq(boardAuthorStudentId)
+            ))
+            .fetch()
+
+        val commentStudents = studentApi.queryByStudentsIds(studentIds.toSet().toList())
+
+        val commentDto = comments.map { comment ->
+            val author = commentStudents.students.find { it.studentId == comment.studentId }?.let {
+                AuthorDto(it.studentId, it.name, it.classNumber, it.studentNumber)
+            }
+
+            val isLiked = commentLikeIds.contains(comment.id)
+
+            CommentDto(
+                commentId = comment.id,
+                content = comment.content,
+                createdAt = comment.createdAt,
+                likeCount = comment.likeCount,
+                isLiked = isLiked,
+                author = author!!
+            )
+
+        }
+
+        val response = GetCommunityBoardInfoResDto(
+            boardId = queryBoard.id,
+            title = queryBoard.title,
+            content = queryBoard.content,
+            likeCount = queryBoard.likeCount,
+            isLiked = isAuthorBoardLike,
+            createdAt = queryBoard.createdAt,
+            stage = stageDto,
+            author = boardAuthorDto.get(0),
+            commentCount = queryBoard.commentCount,
+            comment = commentDto
+        )
+
+        return response
+
     }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.community.root.presentation
 
 import gogo.gogostage.domain.community.root.application.CommunityService
+import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
 import gogo.gogostage.domain.community.root.persistence.SortType
@@ -41,6 +42,14 @@ class CommunityController(
     ): ResponseEntity<GetCommunityBoardResDto> {
         val response = communityService.getStageBoard(
             stageId, page, size, category, sort)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/board/{board_id}")
+    fun getStageBoardInfo(
+        @PathVariable("board_id") boardId: Long
+    ): ResponseEntity<GetCommunityBoardInfoResDto> {
+        val response = communityService.getStageBoardInfo(boardId)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -49,6 +49,7 @@ class SecurityConfig(
             // community
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/board/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()


### PR DESCRIPTION
# 개요
경기 게시글 상세보기 API를 개발하였습니다.

# 본문
* boardId를 Path를 받아 해당 board를 조회 후 board의 Author과 board에 대한 comment를 조회합니다.
* comment의 Author을 불러 Dto에 넣습니다.
* 또한, board와 comment의 좋아요 여부를 같이 반환합니다.