### PR TITLE
[community] 경기 게시글 좋아요 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
@@ -1,0 +1,18 @@
+package gogo.gogostage.domain.community.board.application
+
+import gogo.gogostage.domain.community.board.persistence.BoardRepository
+import gogo.gogostage.global.error.StageException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class BoardReader(
+    private val boardRepository: BoardRepository
+) {
+
+    fun read(boardId: Long) =
+        boardRepository.findByIdOrNull(boardId)
+            ?: throw StageException("Board Not Found", HttpStatus.NOT_FOUND.value())
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
@@ -13,6 +13,6 @@ class BoardReader(
 
     fun read(boardId: Long) =
         boardRepository.findByIdOrNull(boardId)
-            ?: throw StageException("Board Not Found", HttpStatus.NOT_FOUND.value())
+            ?: throw StageException("Board Not Found, boardId=$boardId", HttpStatus.NOT_FOUND.value())
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
@@ -29,11 +29,21 @@ class Board(
     val commentCount: Int,
 
     @Column(name = "like_count", nullable = false)
-    val likeCount: Int,
+    var likeCount: Int,
 
     @Column(name = "is_filtered", nullable = false)
     val isFiltered: Boolean,
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime
-)
+) {
+
+    fun minusLikeCount() {
+        likeCount -= 1
+    }
+
+    fun plusLikeCount() {
+        likeCount += 1
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLike.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLike.kt
@@ -9,7 +9,7 @@ class BoardLike(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    val id: Long,
+    val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)

--- a/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLikeRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/boardlike/persistence/BoardLikeRepository.kt
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface BoardLikeRepository: JpaRepository<BoardLike, Long> {
     fun existsByStudentIdAndBoardId(studentId: Long, boardId: Long): Boolean
+    fun findByBoardIdAndStudentId(boardId: Long, studentId: Long): BoardLike?
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -19,7 +19,7 @@ class CommunityProcessor(
 
         if (isExistBoardLike) {
             val boardLike = boardLikeRepository.findByBoardIdAndStudentId(board.id, studentId)
-                ?: throw StageException("BoardLike Not Found", HttpStatus.NOT_FOUND.value())
+                ?: throw StageException("BoardLike Not Found, boardId=${board.id}, studentId=$studentId", HttpStatus.NOT_FOUND.value())
 
             boardLikeRepository.delete(boardLike)
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.persistence.Board
+import gogo.gogostage.domain.community.board.persistence.BoardRepository
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLike
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
 import gogo.gogostage.domain.community.root.application.dto.LikeBoardResDto
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 class CommunityProcessor(
     private val boardLikeRepository: BoardLikeRepository,
+    private val boardRepository: BoardRepository,
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeBoardResDto {
@@ -23,6 +25,9 @@ class CommunityProcessor(
 
             boardLikeRepository.delete(boardLike)
 
+            board.minusLikeCount()
+            boardRepository.save(board)
+
             return LikeBoardResDto(
                 isLiked = false
             )
@@ -33,6 +38,9 @@ class CommunityProcessor(
             )
 
             boardLikeRepository.save(boardLike)
+
+            board.plusLikeCount()
+            boardRepository.save(board)
 
             return LikeBoardResDto(
                 isLiked = true

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -1,0 +1,42 @@
+package gogo.gogostage.domain.community.root.application
+
+import gogo.gogostage.domain.community.board.persistence.Board
+import gogo.gogostage.domain.community.boardlike.persistence.BoardLike
+import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
+import gogo.gogostage.domain.community.root.application.dto.LikeBoardResDto
+import gogo.gogostage.global.error.StageException
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class CommunityProcessor(
+    private val boardLikeRepository: BoardLikeRepository,
+) {
+
+    fun likeBoard(studentId: Long, board: Board): LikeBoardResDto {
+        // 동시성 문제
+        val isExistBoardLike = boardLikeRepository.existsByStudentIdAndBoardId(studentId, board.id)
+
+        if (isExistBoardLike) {
+            val boardLike = boardLikeRepository.findByBoardIdAndStudentId(board.id, studentId)
+                ?: throw StageException("BoardLike Not Found", HttpStatus.NOT_FOUND.value())
+
+            boardLikeRepository.delete(boardLike)
+
+            return LikeBoardResDto(
+                isLiked = false
+            )
+        } else {
+            val boardLike = BoardLike(
+                board = board,
+                studentId = studentId
+            )
+
+            boardLikeRepository.save(boardLike)
+
+            return LikeBoardResDto(
+                isLiked = true
+            )
+        }
+    }
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.community.root.application
 
+import gogo.gogostage.domain.community.board.application.BoardReader
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class CommunityReader(
-    private val communityRepository: CommunityRepository
+    private val communityRepository: CommunityRepository,
+    private val boardReader: BoardReader
 ) {
 
     fun readByStageId(stageId: Long) =
@@ -27,4 +29,8 @@ class CommunityReader(
 
     fun readBoardInfo(boardId: Long): GetCommunityBoardInfoResDto =
         communityRepository.getCommunityBoardInfo(boardId)
+
+    fun readBoardByBoardId(boardId: Long) =
+        boardReader.read(boardId)
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
@@ -1,8 +1,6 @@
 package gogo.gogostage.domain.community.root.application
 
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
-import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 
@@ -10,4 +8,5 @@ interface CommunityService {
     fun writeCommunityBoard(stageId: Long, writeCommunityBoardDto: WriteCommunityBoardDto)
     fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto
     fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto
+    fun likeStageBoard(boardId: Long): LikeBoardResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -1,9 +1,7 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardProcessor
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
-import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.global.util.UserContextUtil
@@ -14,7 +12,8 @@ import org.springframework.transaction.annotation.Transactional
 class CommunityServiceImpl(
     private val communityReader: CommunityReader,
     private val boardProcessor: BoardProcessor,
-    private val userUtil: UserContextUtil
+    private val userUtil: UserContextUtil,
+    private val communityProcessor: CommunityProcessor,
 ): CommunityService {
 
     @Transactional
@@ -36,5 +35,11 @@ class CommunityServiceImpl(
         return communityReader.readBoardInfo(boardId)
     }
 
+    @Transactional
+    override fun likeStageBoard(boardId: Long): LikeBoardResDto {
+        val student = userUtil.getCurrentStudent()
+        val board = communityReader.readBoardByBoardId(boardId)
+        return communityProcessor.likeBoard(student.studentId, board)
+    }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -73,3 +73,7 @@ data class CommentDto(
     val isLiked: Boolean,
     val author: AuthorDto
 )
+
+data class LikeBoardResDto(
+    val isLiked: Boolean,
+)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -1,9 +1,7 @@
 package gogo.gogostage.domain.community.root.presentation
 
 import gogo.gogostage.domain.community.root.application.CommunityService
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
-import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
-import gogo.gogostage.domain.community.root.application.dto.WriteCommunityBoardDto
+import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 import jakarta.validation.Valid
@@ -51,5 +49,13 @@ class CommunityController(
     ): ResponseEntity<GetCommunityBoardInfoResDto> {
         val response = communityService.getStageBoardInfo(boardId)
         return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/board/like/{board_id}")
+    fun likeStageBoard(
+        @PathVariable("board_id") boardId: Long
+    ): ResponseEntity<LikeBoardResDto> {
+        val response = communityService.likeStageBoard(boardId)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -56,6 +56,6 @@ class CommunityController(
         @PathVariable("board_id") boardId: Long
     ): ResponseEntity<LikeBoardResDto> {
         val response = communityService.likeStageBoard(boardId)
-        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/board/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/board/like/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()


### PR DESCRIPTION
# 개요
경기 게시글을 좋아요할 수 있는 API를 추가하였습니다

# 본문
<img width="871" alt="스크린샷 2025-03-12 오후 8 23 14" src="https://github.com/user-attachments/assets/170ce72f-12a6-4b12-bea5-be20acf2f318" />

* boardId를 받아 해당 board를 조회합니다.
* board와 토큰을 통해 student를 가져와 proceessor로 이동합니다.
* processor에서 boardId와 studentId로 boardLike 여부를 boolean으로 반환합니다.
* 만약에 존재한다면 해당 boardLike를 지우고 false를 반환합니다.
* 존재하지 않는다면 boardLike 엔티티를 생성하여 추가합니다.