### PR TITLE
[comment] 경기 게시글 댓글 작성 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/Comment.kt
@@ -10,7 +10,7 @@ class Comment(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    val id: Long,
+    val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)

--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/CommentRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/CommentRepository.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.community.comment.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository: JpaRepository<Comment, Long> {
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityMapper.kt
@@ -1,0 +1,31 @@
+package gogo.gogostage.domain.community.root.application
+
+import gogo.gogostage.domain.community.comment.persistence.Comment
+import gogo.gogostage.domain.community.root.application.dto.AuthorDto
+import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentReqDto
+import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentResDto
+import gogo.gogostage.global.internal.student.stub.StudentByIdStub
+import org.springframework.stereotype.Component
+
+@Component
+class CommunityMapper {
+
+    fun mapWriteBoardCommentResDto(
+        comment: Comment,
+        writeBoardCommentDto: WriteBoardCommentReqDto,
+        student: StudentByIdStub
+    ) =
+        WriteBoardCommentResDto(
+            commentId = comment.id,
+            content = writeBoardCommentDto.content,
+            createdAt = comment.createdAt,
+            likeCount = comment.likeCount,
+            author = AuthorDto(
+                studentId = student.studentId,
+                name = student.name,
+                classNumber = student.classNumber,
+                studentNumber = student.studentNumber
+            )
+        )
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -3,14 +3,22 @@ package gogo.gogostage.domain.community.root.application
 import gogo.gogostage.domain.community.board.persistence.Board
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLike
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
+import gogo.gogostage.domain.community.comment.persistence.Comment
+import gogo.gogostage.domain.community.comment.persistence.CommentRepository
+import gogo.gogostage.domain.community.root.application.dto.AuthorDto
 import gogo.gogostage.domain.community.root.application.dto.LikeBoardResDto
+import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentReqDto
+import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentResDto
 import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import java.time.LocalDateTime
 
 @Component
 class CommunityProcessor(
     private val boardLikeRepository: BoardLikeRepository,
+    private val commentRepository: CommentRepository,
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeBoardResDto {
@@ -38,5 +46,35 @@ class CommunityProcessor(
                 isLiked = true
             )
         }
+    }
+
+    fun saveBoardComment(
+        student: StudentByIdStub,
+        writeBoardCommentDto: WriteBoardCommentReqDto,
+        board: Board
+    ): WriteBoardCommentResDto {
+        val comment = Comment(
+            board = board,
+            studentId = student.studentId,
+            content = writeBoardCommentDto.content,
+            isFiltered = false,
+            createdAt = LocalDateTime.now(),
+            likeCount = 0
+        )
+
+        commentRepository.save(comment)
+
+        return WriteBoardCommentResDto(
+            commentId = comment.id,
+            content = writeBoardCommentDto.content,
+            createdAt = comment.createdAt,
+            likeCount = comment.likeCount,
+            author = AuthorDto(
+                studentId = student.studentId,
+                name = student.name,
+                classNumber = student.classNumber,
+                studentNumber = student.studentNumber
+            )
+        )
     }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -6,7 +6,6 @@ import gogo.gogostage.domain.community.boardlike.persistence.BoardLike
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
 import gogo.gogostage.domain.community.comment.persistence.Comment
 import gogo.gogostage.domain.community.comment.persistence.CommentRepository
-import gogo.gogostage.domain.community.root.application.dto.AuthorDto
 import gogo.gogostage.domain.community.root.application.dto.LikeBoardResDto
 import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentReqDto
 import gogo.gogostage.domain.community.root.application.dto.WriteBoardCommentResDto
@@ -20,7 +19,8 @@ import java.time.LocalDateTime
 class CommunityProcessor(
     private val boardLikeRepository: BoardLikeRepository,
     private val commentRepository: CommentRepository,
-    private val boardRepository: BoardRepository
+    private val boardRepository: BoardRepository,
+    private val communityMapper: CommunityMapper
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeBoardResDto {
@@ -72,17 +72,6 @@ class CommunityProcessor(
 
         commentRepository.save(comment)
 
-        return WriteBoardCommentResDto(
-            commentId = comment.id,
-            content = writeBoardCommentDto.content,
-            createdAt = comment.createdAt,
-            likeCount = comment.likeCount,
-            author = AuthorDto(
-                studentId = student.studentId,
-                name = student.name,
-                classNumber = student.classNumber,
-                studentNumber = student.studentNumber
-            )
-        )
+        return communityMapper.mapWriteBoardCommentResDto(comment, writeBoardCommentDto, student)
     }
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityService.kt
@@ -9,4 +9,5 @@ interface CommunityService {
     fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto
     fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto
     fun likeStageBoard(boardId: Long): LikeBoardResDto
+    fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -42,4 +42,11 @@ class CommunityServiceImpl(
         return communityProcessor.likeBoard(student.studentId, board)
     }
 
+    @Transactional
+    override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
+        val student = userUtil.getCurrentStudent()
+        val board = communityReader.readBoardByBoardId(boardId)
+        return communityProcessor.saveBoardComment(student, writeBoardCommentDto, board)
+    }
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -46,6 +46,7 @@ class CommunityServiceImpl(
     override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
+        // 욕설 필터링 필요
         return communityProcessor.saveBoardComment(student, writeBoardCommentDto, board)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -77,3 +77,17 @@ data class CommentDto(
 data class LikeBoardResDto(
     val isLiked: Boolean,
 )
+
+data class WriteBoardCommentReqDto(
+    @NotNull
+    val content: String,
+)
+
+data class WriteBoardCommentResDto(
+    val commentId: Long,
+    val content: String,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    val createdAt: LocalDateTime,
+    val likeCount: Int,
+    val author: AuthorDto,
+)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/presentation/CommunityController.kt
@@ -58,4 +58,13 @@ class CommunityController(
         val response = communityService.likeStageBoard(boardId)
         return ResponseEntity.status(HttpStatus.CREATED).body(response)
     }
+
+    @PostMapping("/comment/{board_id}")
+    fun writeBoardComment(
+        @PathVariable("board_id") boardId: Long,
+        @RequestBody @Valid writeBoardCommentDto: WriteBoardCommentReqDto
+    ): ResponseEntity<WriteBoardCommentResDto> {
+        val response = communityService.writeBoardComment(boardId, writeBoardCommentDto)
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/board/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/board/like/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/comment/{board_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()


### PR DESCRIPTION
# 개요
경기 게시글 댓글을 작성하는 API를 추가하였습니다.

# 본문
<img width="847" alt="스크린샷 2025-03-13 오전 12 30 24" src="https://github.com/user-attachments/assets/627ea5a4-b2e4-4e9e-8926-8481a4fa2ed6" />

* boardId, WriteBoardCommentReqDto을 Path와 Body로 요청을 받습니다.
* 받은 후, 같이 보낸 토큰을 가지고 student를 가져옵니다.
* 그 후 boardId로 board를 조회합니다.
* board와 student, WriteBoardCommentReqDto를 가지고 comment를 저장합니다.