### PR TITLE
[stage] 스테이지 확정 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -24,7 +24,7 @@ class Game(
     val name: String,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false)
+    @Column(name = "system", nullable = false)
     val system: GameSystem,
 
     @Column(name = "team_min_capacity", nullable = false)

--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/GameRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/GameRepository.kt
@@ -2,4 +2,6 @@ package gogo.gogostage.domain.game.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface GameRepository : JpaRepository<Game, Long>
+interface GameRepository : JpaRepository<Game, Long> {
+    fun countByStageId(stageId: Long): Int
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -11,29 +11,29 @@ class Match(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
-    val id: Long,
+    val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id", nullable = false)
     val game: Game,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "a_team_id", nullable = false)
-    val aTeam: Team,
+    @JoinColumn(name = "a_team_id", nullable = true)
+    val aTeam: Team? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "b_team_id", nullable = false)
-    val bTeam: Team,
+    @JoinColumn(name = "b_team_id", nullable = true)
+    val bTeam: Team? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "round", nullable = true)
-    val round: Round?,
+    val round: Round? = null,
 
     @Column(name = "turn", nullable = true)
-    val turn: Int?,
+    val turn: Int? = null,
 
     @Column(name = "leagueTurn", nullable = true)
-    val leagueTurn: Int?,
+    val leagueTurn: Int? = null,
 
     @Column(name = "start_date", nullable = false)
     val startDate: LocalDateTime,
@@ -42,14 +42,66 @@ class Match(
     val endDate: LocalDateTime,
 
     @Column(name = "is_end", nullable = false)
-    var isEnd: Boolean,
+    var isEnd: Boolean = false,
 
     @Column(name = "a_team_betting_point", nullable = false)
-    var aTeamBettingPoint: Long,
+    var aTeamBettingPoint: Long = 0,
 
     @Column(name = "b_team_betting_point", nullable = false)
-    var bTeamBettingPoint: Long,
+    var bTeamBettingPoint: Long = 0,
 ) {
+
+    companion object {
+
+        fun singleOf(
+            game: Game,
+            aTeam: Team,
+            bTeam: Team,
+            startDate: LocalDateTime,
+            endDate: LocalDateTime
+        ) = Match(
+            game = game,
+            aTeam = aTeam,
+            bTeam = bTeam,
+            startDate = startDate,
+            endDate = endDate,
+        )
+
+        fun tournamentOf(
+            game: Game,
+            aTeam: Team?,
+            bTeam: Team?,
+            startDate: LocalDateTime,
+            endDate: LocalDateTime,
+            round: Round,
+            turn: Int,
+        ) = Match(
+            game = game,
+            aTeam = aTeam,
+            bTeam = bTeam,
+            startDate = startDate,
+            endDate = endDate,
+            round = round,
+            turn = turn,
+        )
+
+        fun leagueOf(
+            game: Game,
+            aTeam: Team,
+            bTeam: Team,
+            startDate: LocalDateTime,
+            endDate: LocalDateTime,
+            leagueTurn: Int,
+        ) = Match(
+            game = game,
+            aTeam = aTeam,
+            bTeam = bTeam,
+            startDate = startDate,
+            endDate = endDate,
+            leagueTurn = leagueTurn
+        )
+
+    }
 
     fun end() {
         isEnd = true

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -67,7 +67,7 @@ class ParticipateProcessor(
         predictedWinTeamId: Long,
         point: Long
     ) {
-        if (match.aTeam.id == predictedWinTeamId) {
+        if (match.aTeam!!.id == predictedWinTeamId) {
             match.addATeamBettingPoint(point)
         } else {
             match.addBTeamBettingPoint(point)
@@ -92,8 +92,8 @@ class ParticipateProcessor(
         val aTeam = match.aTeam
         val bTeam = match.bTeam
 
-        val isATeamParticipant = aTeam.participants.any { participant -> participant.studentId == studentId }
-        val isBTeamParticipant = bTeam.participants.any { participant -> participant.studentId == studentId }
+        val isATeamParticipant = aTeam!!.participants.any { participant -> participant.studentId == studentId }
+        val isBTeamParticipant = bTeam!!.participants.any { participant -> participant.studentId == studentId }
 
         if (isATeamParticipant || isBTeamParticipant) {
             throw StageException("Can't Betting Match Player", HttpStatus.BAD_REQUEST.value())

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageService.kt
@@ -2,10 +2,12 @@ package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
+import gogo.gogostage.domain.stage.root.application.dto.StageConfirmDto
 import gogo.gogostage.domain.stage.root.application.dto.StageJoinDto
 
 interface StageService {
     fun createFast(dto: CreateFastStageDto)
     fun createOfficial(dto: CreateOfficialStageDto)
     fun join(stageId: Long, dto: StageJoinDto)
+    fun confirm(stageId: Long, dto: StageConfirmDto)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -72,7 +72,12 @@ class StageServiceImpl(
 
         stageProcessor.confirm(stage, dto)
 
-        TODO("스테이지 확정 이벤트 발행")
+        applicationEventPublisher.publishEvent(
+            StageConfirmEvent(
+                id = UUID.randomUUID().toString(),
+                stageId = stage.id,
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -2,6 +2,7 @@ package gogo.gogostage.domain.stage.root.application
 
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
+import gogo.gogostage.domain.stage.root.application.dto.StageConfirmDto
 import gogo.gogostage.domain.stage.root.application.dto.StageJoinDto
 import gogo.gogostage.domain.stage.root.event.*
 import gogo.gogostage.domain.stage.root.persistence.StageRepository
@@ -59,6 +60,19 @@ class StageServiceImpl(
         stageValidator.validJoin(student, dto, stage)
 
         stageProcessor.join(student, stage)
+    }
+
+    @Transactional
+    override fun confirm(stageId: Long, dto: StageConfirmDto) {
+        val stage = stageRepository.queryNotEndStageById(stageId)
+            ?: throw StageException("Stage Not Found, Stage Id = $stageId", HttpStatus.NOT_FOUND.value())
+
+        val student = userUtil.getCurrentStudent()
+        stageValidator.validConfirm(student, stage, dto)
+
+        stageProcessor.confirm(stage, dto)
+
+        TODO("스테이지 확정 이벤트 발행")
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.stage.root.application
 
+import gogo.gogostage.domain.game.persistence.GameRepository
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
@@ -14,7 +15,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class StageValidator(
-    private val stageParticipantRepository: StageParticipantRepository
+    private val stageParticipantRepository: StageParticipantRepository,
+    private val gameRepository: GameRepository
 ) {
 
     fun validFast(dto: CreateFastStageDto) {
@@ -61,6 +63,11 @@ class StageValidator(
         val stageStatus = stage.status
         if (stageStatus != StageStatus.RECRUITING) {
             throw StageException("해당 스테이지는 모집 중인 스테이지가 아닙니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        val gameCount = gameRepository.countByStageId(stage.id)
+        if (gameCount != dto.games.size) {
+            throw StageException("해당 스테이지의 게임 수와 확정된 게임 수가 일치하지 않습니다.", HttpStatus.BAD_REQUEST.value())
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -3,8 +3,10 @@ package gogo.gogostage.domain.stage.root.application
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
+import gogo.gogostage.domain.stage.root.application.dto.StageConfirmDto
 import gogo.gogostage.domain.stage.root.application.dto.StageJoinDto
 import gogo.gogostage.domain.stage.root.persistence.Stage
+import gogo.gogostage.domain.stage.root.persistence.StageStatus
 import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.http.HttpStatus
@@ -47,6 +49,18 @@ class StageValidator(
         val isSchool = stage.schoolId == student.schoolId
         if (isSchool) {
             throw StageException("해당 스테이지는 현재 소속 중인 학교의 스테이지가 아닙니다.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+    fun validConfirm(student: StudentByIdStub, stage: Stage, dto: StageConfirmDto) {
+        val isMaintainer = stage.maintainer.any{ it.studentId == student.studentId }
+        if (isMaintainer.not()) {
+            throw StageException("해당 스테이지의 관리자가 아닙니다.", HttpStatus.FORBIDDEN.value())
+        }
+
+        val stageStatus = stage.status
+        if (stageStatus != StageStatus.RECRUITING) {
+            throw StageException("해당 스테이지는 모집 중인 스테이지가 아닙니다.", HttpStatus.BAD_REQUEST.value())
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
@@ -2,9 +2,11 @@ package gogo.gogostage.domain.stage.root.application.dto
 
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.match.root.persistence.Round
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
+import java.time.LocalDateTime
 
 data class CreateFastStageDto(
     @NotBlank
@@ -99,4 +101,39 @@ data class MiniGameInfoDto(
 
 data class StageJoinDto(
     val passCode: String?,
+)
+
+data class StageConfirmDto(
+    val games: List<StageConfirmGameDto>
+)
+
+data class StageConfirmGameDto(
+    val gameId: Long,
+    val single: StageConfirmGameSingleDto?,
+    val tournament: List<StageConfirmGameTournamentDto>?,
+    val fullLeague: List<StageConfirmGameFullLeagueDto>?,
+)
+
+data class StageConfirmGameSingleDto(
+    val teamAId: Long,
+    val teamBId: Long,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime
+)
+
+data class StageConfirmGameTournamentDto(
+    val teamAId: Long?,
+    val teamBId: Long?,
+    val round: Round,
+    val turn: Int,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime
+)
+
+data class StageConfirmGameFullLeagueDto(
+    val teamAId: Long,
+    val teamBId: Long,
+    val leagueTurn: Int,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/listener/StageApplicationEventListener.kt
@@ -2,6 +2,7 @@ package gogo.gogostage.domain.stage.root.application.listener
 
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
+import gogo.gogostage.domain.stage.root.event.StageConfirmEvent
 import gogo.gogostage.global.kafka.publisher.StagePublisher
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -28,6 +29,14 @@ class StageApplicationEventListener(
         with(event) {
             log.info("published create stage official application event: {}", id)
             stagePublisher.publishCreateStageOfficialEvent(event)
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun createStageOfficial(event: StageConfirmEvent) {
+        with(event) {
+            log.info("published stage confirm application event: {}", id)
+            stagePublisher.publishStageConfirmEvent(event)
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/StageConfirmEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/StageConfirmEvent.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.domain.stage.root.event
+
+data class StageConfirmEvent(
+    val id: String,
+    val stageId: Long
+)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
@@ -1,5 +1,7 @@
 package gogo.gogostage.domain.stage.root.persistence
 
+import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.stage.maintainer.persistence.StageMaintainer
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
@@ -48,6 +50,12 @@ class Stage(
 
     @Column(name = "created_at", nullable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @OneToMany(mappedBy = "stage", cascade = [(CascadeType.ALL)], orphanRemoval = true)
+    val maintainer: List<StageMaintainer> = listOf(),
+
+    @OneToMany(mappedBy = "stage", cascade = [(CascadeType.ALL)], orphanRemoval = true)
+    val game: List<Game> = listOf(),
 ) {
     companion object {
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/Stage.kt
@@ -37,7 +37,7 @@ class Stage(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
-    val status: StageStatus,
+    var status: StageStatus,
 
     @Column(name = "participant_count", nullable = false)
     val participantCount: Int,
@@ -86,6 +86,11 @@ class Stage(
         )
 
     }
+
+    fun confirm() {
+        this.status = StageStatus.CONFIRMED
+    }
+
 }
 
 enum class StageType {

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/presentation/StageController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/presentation/StageController.kt
@@ -3,6 +3,7 @@ package gogo.gogostage.domain.stage.root.presentation
 import gogo.gogostage.domain.stage.root.application.StageService
 import gogo.gogostage.domain.stage.root.application.dto.CreateFastStageDto
 import gogo.gogostage.domain.stage.root.application.dto.CreateOfficialStageDto
+import gogo.gogostage.domain.stage.root.application.dto.StageConfirmDto
 import gogo.gogostage.domain.stage.root.application.dto.StageJoinDto
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -37,6 +38,15 @@ class StageController(
         @RequestBody dto: StageJoinDto,
     ): ResponseEntity<Unit> {
         stageService.join(stageId, dto)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/confirm/{stage_id}")
+    fun confirm(
+        @PathVariable("stage_id") stageId: Long,
+        @RequestBody dto: StageConfirmDto,
+    ): ResponseEntity<Unit> {
+        stageService.confirm(stageId, dto)
         return ResponseEntity.ok().build()
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamValidator.kt
@@ -18,8 +18,10 @@ class TeamValidator(
 ) {
 
     fun validApply(student: StudentByIdStub, game: Game, dto: TeamApplyDto) {
-        val isParticipant =
-            stageParticipantRepository.existsByStageIdAndStudentId(student.studentId, game.stage.id)
+        val isParticipant = stageParticipantRepository.existsByStageIdAndStudentId(
+            stageId = game.stage.id,
+            studentId = student.studentId
+        )
         if (isParticipant.not()) {
             throw StageException("스테이지 참여자가 아닙니다.", HttpStatus.FORBIDDEN.value())
         }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -26,7 +26,7 @@ class Team(
     val participantCount: Int,
 
     @Column(name = "is_participating", nullable = false)
-    val isParticipating: Boolean = false,
+    var isParticipating: Boolean = false,
 
     @OneToMany(mappedBy = "team")
     val participants: MutableList<TeamParticipant> = mutableListOf(),
@@ -40,4 +40,14 @@ class Team(
         )
 
     }
+
+    fun participation(): Int {
+        if (isParticipating) {
+            return 0
+        } else {
+            this.isParticipating = true
+            return 1
+        }
+    }
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/presentation/TeamController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/presentation/TeamController.kt
@@ -1,3 +1,5 @@
+package gogo.gogostage.domain.team.root.presentation
+
 import gogo.gogostage.domain.team.root.application.dto.TeamApplyDto
 
 import gogo.gogostage.domain.team.root.application.TeamService
@@ -12,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/stage")
-class TeamController(private val teamService: TeamService) {
+class TeamController(
+    private val teamService: TeamService
+) {
 
     @PostMapping("/team/{game_id}")
     fun apply(

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -51,6 +51,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/official").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/join/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/team/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/confirm/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // server to server
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/api/point/{stage_id}").permitAll()

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -13,4 +13,5 @@ object KafkaTopics {
     const val TICKET_ADDITION_FAILED = "ticket_addition_failed"
     const val STAGE_CREATE_OFFICIAL = "stage_create_official"
     const val STAGE_CREATE_FAST = "stage_create_fast"
+    const val STAGE_CONFIRM = "stage_confirm"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -3,6 +3,7 @@ package gogo.gogostage.global.kafka.publisher
 import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
+import gogo.gogostage.domain.stage.root.event.StageConfirmEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
@@ -12,6 +13,7 @@ import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TE
 import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CREATE_OFFICIAL
 import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CREATE_FAST
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
+import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CONFIRM
 import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS
 import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS_FAILED
 import gogo.gogostage.global.publisher.TransactionEventPublisher
@@ -73,6 +75,17 @@ class StagePublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = STAGE_CREATE_OFFICIAL,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishStageConfirmEvent(
+        event: StageConfirmEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = STAGE_CONFIRM,
             key = key,
             event = event
         )


### PR DESCRIPTION
## 개요
스테이지 확정 API를 개발하였습니다.

## 본문
- 사설, 공식 스테이지를 확정합니다.
- 단판, 토너먼트, 풀리그 경기 시스템을 기준으로 나누어 매치를 생성, 저장합니다.
- 스테이지 관려지인지, 모집 중인 스테이지인지, 모든 경기를 확정했는지, 각 시스템 경기마다 매치 수가 올바른지 validation 합니다.
- 확정된 팀은 isParticipant를 true로 변경, stage는 CONFIRM 상태로 변경합니다. 이후에 `stage_confrim` 토픽에 이벤트를 발행하여 MiniGame, Shop 서비스의 상태를 변경합니다.