### PR TITLE
[stage] 매치 정산, 정산취소 이벤트 핸들링 후처리 작업

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -35,21 +35,24 @@ class Game(
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "first_place_team_id", nullable = true)
-    val firstPlaceTeam: Team? = null,
+    var firstPlaceTeam: Team? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "second_place_team_id", nullable = true)
-    val secondPlaceTeam: Team? = null,
+    var secondPlaceTeam: Team? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "third_place_team_id", nullable = true)
-    val thirdPlaceTeam: Team? = null,
+    var thirdPlaceTeam: Team? = null,
 
     @Column(name = "team_count", nullable = false)
-    val teamCount: Int = 0,
+    val teamCount: Int = 0, // 팀 신청시 ++
+
+    @Column(name = "league_count", nullable = true)
+    var leagueCount: Int? = null,
 
     @Column(name = "is_end", nullable = false)
-    val isEnd: Boolean = false
+    var isEnd: Boolean = false
 ){
     companion object {
 
@@ -70,6 +73,18 @@ class Game(
         )
 
     }
+
+    fun updateLeagueCount(leagueCount: Int) {
+        this.leagueCount = leagueCount
+    }
+
+    fun end(firstPlaceTeam: Team?, secondPlaceTeam: Team?, thirdPlaceTeam: Team? = null) {
+        this.isEnd = true
+        this.firstPlaceTeam = firstPlaceTeam
+        this.secondPlaceTeam = secondPlaceTeam
+        this.thirdPlaceTeam = thirdPlaceTeam
+    }
+
 }
 
 enum class GameCategory {

--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -37,14 +37,6 @@ class Game(
     @JoinColumn(name = "first_place_team_id", nullable = true)
     var firstPlaceTeam: Team? = null,
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "second_place_team_id", nullable = true)
-    var secondPlaceTeam: Team? = null,
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "third_place_team_id", nullable = true)
-    var thirdPlaceTeam: Team? = null,
-
     @Column(name = "team_count", nullable = false)
     val teamCount: Int = 0, // 팀 신청시 ++
 
@@ -78,11 +70,14 @@ class Game(
         this.leagueCount = leagueCount
     }
 
-    fun end(firstPlaceTeam: Team?, secondPlaceTeam: Team?, thirdPlaceTeam: Team? = null) {
+    fun end(firstPlaceTeam: Team?) {
         this.isEnd = true
         this.firstPlaceTeam = firstPlaceTeam
-        this.secondPlaceTeam = secondPlaceTeam
-        this.thirdPlaceTeam = thirdPlaceTeam
+    }
+
+    fun gameEndRollBack() {
+        this.isEnd = false
+        this.firstPlaceTeam = null
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -75,7 +75,7 @@ class Game(
         this.firstPlaceTeam = firstPlaceTeam
     }
 
-    fun gameEndRollBack() {
+    fun endRollBack() {
         this.isEnd = false
         this.firstPlaceTeam = null
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -100,6 +100,29 @@ class MatchProcessor(
         matchRepository.save(match)
 
         val game = match.game
+        if (game.system == GameSystem.TOURNAMENT && match.round!! != Round.FINALS) {
+
+            when (match.round!!) {
+                Round.ROUND_OF_32 -> {
+                    updateNextMatch(match, null, Round.ROUND_OF_16)
+                }
+
+                Round.ROUND_OF_16 -> {
+                    updateNextMatch(match, null, Round.QUARTER_FINALS)
+                }
+
+                Round.QUARTER_FINALS -> {
+                    updateNextMatch(match, null, Round.SEMI_FINALS)
+                }
+
+                Round.SEMI_FINALS -> {
+                    updateNextMatch(match, null, Round.FINALS)
+                }
+                else -> {}
+            }
+
+        }
+
         if (game.isEnd) {
             game.endRollBack()
             gameRepository.save(game)
@@ -112,7 +135,7 @@ class MatchProcessor(
 
     private fun gameEnd(
         match: Match,
-        victoryTeam: Team
+        victoryTeam: Team?
     ) {
         val game = match.game
         game.end(victoryTeam)
@@ -121,7 +144,7 @@ class MatchProcessor(
 
     private fun updateNextMatch(
         match: Match,
-        victoryTeam: Team,
+        updateTeam: Team?,
         nextRound: Round
     ) {
         val nextTurn = if (match.turn!! % 2 == 0) match.turn!! / 2 else match.turn!! / 2 + 1
@@ -132,11 +155,11 @@ class MatchProcessor(
 
         when (nextTeamPosition) {
             'A' -> {
-                nextMatch.updateATeam(victoryTeam)
+                nextMatch.updateATeam(updateTeam)
             }
 
             'B' -> {
-                nextMatch.updateBTeam(victoryTeam)
+                nextMatch.updateBTeam(updateTeam)
             }
         }
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -1,0 +1,91 @@
+package gogo.gogostage.domain.match.root.application
+
+import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.match.result.persistence.MatchResult
+import gogo.gogostage.domain.match.result.persistence.MatchResultRepository
+import gogo.gogostage.domain.match.root.persistence.Match
+import gogo.gogostage.domain.match.root.persistence.MatchRepository
+import gogo.gogostage.domain.match.root.persistence.Round
+import gogo.gogostage.domain.stage.participant.temppoint.application.TempPointProcessor
+import gogo.gogostage.domain.team.root.persistence.Team
+import gogo.gogostage.domain.team.root.persistence.TeamRepository
+import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.kafka.consumer.dto.MatchBatchEvent
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class MatchProcessor(
+    private val matchRepository: MatchRepository,
+    private val teamRepository: TeamRepository,
+    private val matchResultRepository: MatchResultRepository,
+    private val tempPointProcessor: TempPointProcessor
+) {
+
+    @Transactional
+    fun batch(event: MatchBatchEvent) {
+        val match = matchRepository.findNotEndMatchById(event.matchId)
+            ?: throw StageException("Match Not Found, Match Id = ${event.matchId}", HttpStatus.NOT_FOUND.value())
+        val victoryTeam = teamRepository.findByIdOrNull(event.victoryTeamId)
+            ?: throw StageException("Victory Team Not Found, Team Id = ${event.victoryTeamId}", HttpStatus.NOT_FOUND.value())
+
+        victoryTeam.addWinCount()
+        teamRepository.save(victoryTeam)
+
+        if (match.game.system == GameSystem.TOURNAMENT) {
+            when (match.round!!) {
+                Round.ROUND_OF_32 -> {
+                    updateNextMatch(match, victoryTeam, Round.ROUND_OF_16)
+                }
+                Round.ROUND_OF_16 -> {
+                    updateNextMatch(match, victoryTeam, Round.QUARTER_FINALS)
+                }
+                Round.QUARTER_FINALS -> {
+                    updateNextMatch(match, victoryTeam, Round.SEMI_FINALS)
+                }
+                Round.SEMI_FINALS -> {
+                    updateNextMatch(match, victoryTeam, Round.FINALS)
+                }
+                Round.FINALS -> return
+            }
+        }
+
+        match.end()
+        matchRepository.save(match)
+
+        val matchResult = MatchResult.of(
+            match = match,
+            victoryTeam = victoryTeam,
+            aTeamScore = event.aTeamScore,
+            bTeamScore = event.bTeamScore,
+        )
+        matchResultRepository.save(matchResult)
+
+        tempPointProcessor.addTempPoint(event)
+    }
+
+    private fun updateNextMatch(
+        match: Match,
+        victoryTeam: Team,
+        nextRound: Round
+    ) {
+        val nextTurn = if (match.turn!! % 2 == 0) match.turn!! / 2 else match.turn!! / 2 + 1
+        val nextTeamPosition = if (match.turn!! % 2 == 0) 'B' else 'A'
+
+        val nextMatch = matchRepository.findByGameIdAndRoundAndTurn(match.game.id, nextRound, nextTurn)
+            ?: throw StageException("Not Found Match, Match Id = ${match.id}", HttpStatus.NOT_FOUND.value())
+
+        when (nextTeamPosition) {
+            'A' -> {
+                nextMatch.updateATeam(victoryTeam)
+            }
+
+            'B' -> {
+                nextMatch.updateBTeam(victoryTeam)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -2,7 +2,9 @@ package gogo.gogostage.domain.match.root.persistence
 
 import gogo.gogostage.domain.game.persistence.Game
 import gogo.gogostage.domain.team.root.persistence.Team
+import gogo.gogostage.global.error.StageException
 import jakarta.persistence.*
+import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 
 @Entity
@@ -19,11 +21,11 @@ class Match(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "a_team_id", nullable = true)
-    val aTeam: Team? = null,
+    var aTeam: Team? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "b_team_id", nullable = true)
-    val bTeam: Team? = null,
+    var bTeam: Team? = null,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "round", nullable = true)
@@ -101,6 +103,22 @@ class Match(
             leagueTurn = leagueTurn
         )
 
+    }
+
+    fun updateATeam(aTeam: Team) {
+        if (this.aTeam != null) {
+            throw StageException("A team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
+        }
+
+        this.aTeam = aTeam
+    }
+
+    fun updateBTeam(bTeam: Team) {
+        if (this.bTeam != null) {
+            throw StageException("B team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
+        }
+
+        this.bTeam = bTeam
     }
 
     fun end() {

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -106,7 +106,7 @@ class Match(
     }
 
     fun updateATeam(aTeam: Team?) {
-        if (this.aTeam != null) {
+        if (aTeam != null && this.aTeam != null) {
             throw StageException("A team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
         }
 
@@ -114,7 +114,7 @@ class Match(
     }
 
     fun updateBTeam(bTeam: Team?) {
-        if (this.bTeam != null) {
+        if (bTeam != null && this.bTeam != null) {
             throw StageException("B team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
         }
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -105,7 +105,7 @@ class Match(
 
     }
 
-    fun updateATeam(aTeam: Team) {
+    fun updateATeam(aTeam: Team?) {
         if (this.aTeam != null) {
             throw StageException("A team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
         }
@@ -113,7 +113,7 @@ class Match(
         this.aTeam = aTeam
     }
 
-    fun updateBTeam(bTeam: Team) {
+    fun updateBTeam(bTeam: Team?) {
         if (this.bTeam != null) {
             throw StageException("B team already exists, Match Id = ${this.id}", HttpStatus.INTERNAL_SERVER_ERROR.value())
         }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.Query
 interface MatchRepository: JpaRepository<Match, Long> {
     @Query("SELECT m FROM Match m WHERE m.id = :matchId AND m.isEnd = false")
     fun findNotEndMatchById(matchId: Long): Match?
+
+    fun findByGameIdAndRoundAndTurn(matchId: Long, round: Round, turn: Int): Match?
 }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/persistence/StageParticipant.kt
@@ -1,7 +1,9 @@
 package gogo.gogostage.domain.stage.participant.root.persistence
 
 import gogo.gogostage.domain.stage.root.persistence.Stage
+import gogo.gogostage.global.error.StageException
 import jakarta.persistence.*
+import org.springframework.http.HttpStatus
 import java.time.LocalDateTime
 
 @Entity
@@ -37,6 +39,10 @@ class StageParticipant(
     }
 
     fun minusPoint(point: Long) {
+        if (this.point - point < 0) {
+            throw StageException("보유 포인트 보다 더 적게 배팅할 수 없습니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
         this.point -= point
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -25,28 +25,10 @@ class TempPointProcessor(
     private val matchResultRepository: MatchResultRepository,
 ) {
 
-    @Transactional
     fun addTempPoint(event: MatchBatchEvent) {
         val match = (matchRepository.findNotEndMatchById(event.matchId)
             ?: throw StageException("Match Not Found, Match Id = ${event.matchId}", HttpStatus.NOT_FOUND.value()))
         val stage = match.game.stage
-
-        val victoryTeam = teamRepository.findByIdOrNull(event.victoryTeamId)
-            ?: throw StageException(
-                "Victory Team Not Found, Team Id = ${event.victoryTeamId}",
-                HttpStatus.NOT_FOUND.value()
-            )
-
-        match.end()
-        matchRepository.save(match)
-
-        val matchResult = MatchResult.of(
-            match = match,
-            victoryTeam = victoryTeam,
-            aTeamScore = event.aTeamScore,
-            bTeamScore = event.bTeamScore,
-        )
-        matchResultRepository.save(matchResult)
 
         // * 정산 취소시 동시성 문제 발생을 방지하기 위해 임시 포인트를 5분 5초 후 만료되도록 설정
         val expiredDate = LocalDateTime.now().plusMinutes(5).plusSeconds(5)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -22,7 +22,7 @@ class TempPointProcessor(
 ) {
 
     fun addTempPoint(event: MatchBatchEvent) {
-        val match = (matchRepository.findNotEndMatchById(event.matchId)
+        val match = (matchRepository.findByIdOrNull(event.matchId)
             ?: throw StageException("Match Not Found, Match Id = ${event.matchId}", HttpStatus.NOT_FOUND.value()))
         val stage = match.game.stage
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
@@ -172,6 +172,9 @@ class StageProcessor(
                         throw StageException("풀 리그 경기의 매치의 수가 맞지 않습니다. 에상 = ${matchCount}, 실제 = ${fullLeague.size}", HttpStatus.BAD_REQUEST.value())
                     }
 
+                    game.updateLeagueCount(matchCount)
+                    gameRepository.save(game)
+
                     matchRepository.saveAll(matches)
                 }
                 GameSystem.TOURNAMENT -> {

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamValidator.kt
@@ -18,8 +18,11 @@ class TeamValidator(
 ) {
 
     fun validApply(student: StudentByIdStub, game: Game, dto: TeamApplyDto) {
-        val isParticipant =
-            stageParticipantRepository.existsByStageIdAndStudentId(student.studentId, game.stage.id)
+        val isParticipant = stageParticipantRepository.existsByStageIdAndStudentId(
+                stageId = game.stage.id,
+                studentId = student.studentId
+            )
+
         if (isParticipant.not()) {
             throw StageException("스테이지 참여자가 아닙니다.", HttpStatus.FORBIDDEN.value())
         }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -28,6 +28,9 @@ class Team(
     @Column(name = "is_participating", nullable = false)
     var isParticipating: Boolean = false,
 
+    @Column(name = "is_survival", nullable = false)
+    val isSurvival: Boolean = true,
+
     @OneToMany(mappedBy = "team")
     val participants: MutableList<TeamParticipant> = mutableListOf(),
 ) {

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -17,7 +17,7 @@ class Team(
     val game: Game,
 
     @Column(name = "win_count", nullable = false)
-    val winCount: Int = 0,
+    var winCount: Int = 0,
 
     @Column(name = "name", nullable = false)
     val name: String,
@@ -48,6 +48,10 @@ class Team(
             this.isParticipating = true
             return 1
         }
+    }
+
+    fun addWinCount() {
+        this.winCount++
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -28,9 +28,6 @@ class Team(
     @Column(name = "is_participating", nullable = false)
     var isParticipating: Boolean = false,
 
-    @Column(name = "is_survival", nullable = false)
-    val isSurvival: Boolean = true,
-
     @OneToMany(mappedBy = "team")
     val participants: MutableList<TeamParticipant> = mutableListOf(),
 ) {

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.Query
 interface TeamRepository: JpaRepository<Team, Long> {
     fun findAllByGameId(gameId: Long): List<Team>
 
-    @Query("SELECT t FROM Team t WHERE t.game.id = :gameId ORDER BY t.winCount DESC LIMIT 3")
-    fun findTop3Teams(gameId: Long): List<Team>
+    @Query("SELECT t FROM Team t WHERE t.game.id = :gameId ORDER BY t.winCount DESC LIMIT 1")
+    fun findTop1Teams(gameId: Long): Team
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/TeamRepository.kt
@@ -1,7 +1,11 @@
 package gogo.gogostage.domain.team.root.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface TeamRepository: JpaRepository<Team, Long> {
     fun findAllByGameId(gameId: Long): List<Team>
+
+    @Query("SELECT t FROM Team t WHERE t.game.id = :gameId ORDER BY t.winCount DESC LIMIT 3")
+    fun findTop3Teams(gameId: Long): List<Team>
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/BatchCancelConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/BatchCancelConsumer.kt
@@ -1,13 +1,11 @@
 package gogo.gogostage.global.kafka.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.match.root.application.MatchProcessor
 import gogo.gogostage.domain.stage.participant.temppoint.application.TempPointProcessor
-import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelEvent
-import gogo.gogostage.global.kafka.consumer.dto.MatchBatchEvent
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL
-import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BATCH
 import gogo.gogostage.global.kafka.publisher.StagePublisher
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -20,8 +18,8 @@ import java.util.*
 @Service
 class BatchCancelConsumer(
     private val objectMapper: ObjectMapper,
-    private val tempPointProcessor: TempPointProcessor,
-    private val stagePublisher: StagePublisher
+    private val stagePublisher: StagePublisher,
+    private val matchProcessor: MatchProcessor
 ) : AcknowledgingMessageListener<String, String> {
 
     private val log = LoggerFactory.getLogger(this::class.java.simpleName)
@@ -37,7 +35,7 @@ class BatchCancelConsumer(
 
         try {
 
-            tempPointProcessor.deleteTempPoint(event)
+            matchProcessor.cancelBatch(event)
 
         } catch (e: Exception) {
             log.error("Failed to Batch Addition Temp Point, Batch Id = ${event.batchId}", e)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MatchBatchConsumer.kt
@@ -1,11 +1,9 @@
 package gogo.gogostage.global.kafka.consumer
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import gogo.gogostage.domain.stage.participant.temppoint.application.TempPointProcessor
+import gogo.gogostage.domain.match.root.application.MatchProcessor
 import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
-import gogo.gogostage.global.kafka.consumer.dto.BatchCancelEvent
 import gogo.gogostage.global.kafka.consumer.dto.MatchBatchEvent
-import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BATCH
 import gogo.gogostage.global.kafka.publisher.StagePublisher
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -19,8 +17,8 @@ import java.util.*
 @Service
 class MatchBatchConsumer(
     private val objectMapper: ObjectMapper,
-    private val tempPointProcessor: TempPointProcessor,
-    private val stagePublisher: StagePublisher
+    private val stagePublisher: StagePublisher,
+    private val matchProcessor: MatchProcessor
 ) : AcknowledgingMessageListener<String, String> {
 
     private val log = LoggerFactory.getLogger(this::class.java.simpleName)
@@ -36,7 +34,7 @@ class MatchBatchConsumer(
 
         try {
 
-            tempPointProcessor.addTempPoint(event)
+            matchProcessor.batch(event)
 
         } catch (e: Exception) {
             log.error("Failed to Cancelled Batch Delete Temp Point, Batch Id = ${event.batchId}", e)


### PR DESCRIPTION
## 개요
매치 정산, 정산취소 이벤트 핸들링 후처리 작업을 하였습니다.

## 본문
정산 이벤트
- 매치 정산시 해당 경기의 모든 매치가 종료되었다면 해당 경기를 종료 처리합니다.
- 토너먼트 매치가 정산되었다면 결승전이 아니라면 승리 팀을 다음 매치에 진출 시킵니다.
- 승리팀 win count를 증가시킵니다.

정산 취소 이벤트
- 마지막 매치가 정산 취소시 경기 종료 롤백처리
- 결승전 매치가 아닌 토너먼트일 경우 상위 매치로 올라간 팀 정보 삭제 처리
