### PR TITLE
[team] 경기에 신청된 팀 조회하기 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -125,15 +125,4 @@ class StageValidator(
         }
     }
 
-    fun validStage(student: StudentByIdStub, stageId: Long) {
-        val stage = (stageRepository.findByIdOrNull(stageId)
-            ?: throw StageException("Stage Not Found, Stage Id = $stageId", HttpStatus.NOT_FOUND.value()))
-
-        val isParticipate = stageParticipantRepository.existsByStageIdAndStudentId(stage.id, student.studentId)
-
-        if (student.schoolId != stage.schoolId || isParticipate.not()) {
-            throw StageException("해당 스테이지에 참여하지 않았습니다.", HttpStatus.FORBIDDEN.value())
-        }
-    }
-
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamService.kt
@@ -6,4 +6,5 @@ import gogo.gogostage.domain.team.root.application.dto.TeamApplyDto
 interface TeamService {
     fun apply(gameId: Long, dto: TeamApplyDto)
     fun getGameTeam(gameId: Long): GameTeamResDto
+    fun getGameTempTeam(gameId: Long): GameTeamResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
@@ -26,12 +26,22 @@ class TeamServiceImpl(
         teamProcessor.apply(game, dto)
     }
 
+    @Transactional(readOnly = true)
     override fun getGameTeam(gameId: Long): GameTeamResDto {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
         teamValidator.validStageParticipant(student.studentId, game.stage.id)
         val teams = teamReader.readParticipatingTeamByGameId(game.id, true)
         return teamMapper.mapGameTeam(teams)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getGameTempTeam(gameId: Long): GameTeamResDto {
+        val student = userUtil.getCurrentStudent()
+        val game = gameReader.read(gameId)
+        teamValidator.validStageParticipant(student.studentId, game.stage.id)
+        val tempTeams = teamReader.readParticipatingTeamByGameId(game.id, false)
+        return teamMapper.mapGameTeam(tempTeams)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
@@ -41,7 +41,7 @@ class TeamServiceImpl(
     override fun getGameTempTeam(gameId: Long): GameTeamResDto {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
-        teamValidator.validStageParticipant(student.studentId, game.stage.id)
+        stageValidator.validStage(student, game.stage.id)
         val tempTeams = teamReader.readParticipatingTeamByGameId(game.id, false)
         return teamMapper.mapGameTeam(tempTeams)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/presentation/TeamController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/presentation/TeamController.kt
@@ -38,4 +38,12 @@ class TeamController(
         return ResponseEntity.ok(response)
     }
 
+    @GetMapping("/team/temp/{game_id}")
+    fun getGameTempTeam(
+        @PathVariable("game_id") gameId: Long
+    ): ResponseEntity<GameTeamResDto> {
+        val response = teamService.getGameTempTeam(gameId)
+        return ResponseEntity.ok(response)
+    }
+
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/team/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/confirm/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/team/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/team/temp/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // community
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)


### PR DESCRIPTION
# 개요
경기에 신청된 팀을 조회하는 API를 개발하였습니다.

# 본문
<img width="880" alt="스크린샷 2025-03-14 오전 11 47 28" src="https://github.com/user-attachments/assets/3033998a-7561-4bc7-874e-0d5a5bd00b85" />

* gameId를 받아 game을 검색하고 student를 토큰을 통해 찾습니다.
* 해당 student가 stageParticipant인지 검증 후 gameId와 isParticipating을 false로 하여 검색한 후 mapper를 거쳐 반환되게 됩니다.