### PR TITLE
[stage] 스테이지 생성 로직 수정

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageMapper.kt
@@ -20,16 +20,19 @@ class StageMapper {
                 isActive = dto.miniGame.coinToss.isActive,
                 maxBettingPoint = dto.miniGame.coinToss.maxBettingPoint,
                 minBettingPoint = dto.miniGame.coinToss.minBettingPoint,
+                initialTicketCount = dto.miniGame.coinToss.initialTicketCount,
             ),
             yavarwee = OfficialStageMiniGameInfoDto(
                 isActive = dto.miniGame.yavarwee.isActive,
                 maxBettingPoint = dto.miniGame.yavarwee.maxBettingPoint,
                 minBettingPoint = dto.miniGame.yavarwee.minBettingPoint,
+                initialTicketCount = dto.miniGame.yavarwee.initialTicketCount,
             ),
             plinko = OfficialStageMiniGameInfoDto(
                 isActive = dto.miniGame.plinko.isActive,
                 maxBettingPoint = dto.miniGame.plinko.maxBettingPoint,
                 minBettingPoint = dto.miniGame.plinko.minBettingPoint,
+                initialTicketCount = dto.miniGame.plinko.initialTicketCount,
             )
         ),
         shop = OfficialStageShopDto(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
@@ -54,10 +54,10 @@ class StageProcessor(
         stageRuleRepository.save(stageRule)
 
         val maintainers =
-            dto.maintainer.toSet().toList().map {
-                if (student.studentId != it) StageMaintainer.of(stage, it)
-                else StageMaintainer.of(stage, student.studentId)
-            }
+            dto.maintainer.toSet().toList()
+                .filter { student.studentId != it }
+                .map { StageMaintainer.of(stage, it) } +
+                    StageMaintainer.of(stage, student.studentId)
         stageMaintainerRepository.saveAll(maintainers)
 
         val gameDto = dto.game
@@ -86,10 +86,10 @@ class StageProcessor(
         stageRuleRepository.save(stageRule)
 
         val maintainers =
-            dto.maintainer.toSet().toList().map {
-                if (student.studentId != it) StageMaintainer.of(stage, it)
-                else StageMaintainer.of(stage, student.studentId)
-            }
+            dto.maintainer.toSet().toList()
+                .filter { student.studentId != it }
+                .map { StageMaintainer.of(stage, it) } +
+                    StageMaintainer.of(stage, student.studentId)
         stageMaintainerRepository.saveAll(maintainers)
 
         val games = dto.game.map { Game.of(stage, it.category, it.name, it.system, it.teamMinCapacity, it.teamMaxCapacity) }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageProcessor.kt
@@ -54,7 +54,10 @@ class StageProcessor(
         stageRuleRepository.save(stageRule)
 
         val maintainers =
-            dto.maintainer.map { StageMaintainer.of(stage, it) } + StageMaintainer.of(stage, student.studentId)
+            dto.maintainer.toSet().toList().map {
+                if (student.studentId != it) StageMaintainer.of(stage, it)
+                else StageMaintainer.of(stage, student.studentId)
+            }
         stageMaintainerRepository.saveAll(maintainers)
 
         val gameDto = dto.game
@@ -83,7 +86,10 @@ class StageProcessor(
         stageRuleRepository.save(stageRule)
 
         val maintainers =
-            dto.maintainer.map { StageMaintainer.of(stage, it) } + StageMaintainer.of(stage, student.studentId)
+            dto.maintainer.toSet().toList().map {
+                if (student.studentId != it) StageMaintainer.of(stage, it)
+                else StageMaintainer.of(stage, student.studentId)
+            }
         stageMaintainerRepository.saveAll(maintainers)
 
         val games = dto.game.map { Game.of(stage, it.category, it.name, it.system, it.teamMinCapacity, it.teamMaxCapacity) }

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageServiceImpl.kt
@@ -38,6 +38,7 @@ class StageServiceImpl(
                     isCoinTossActive = stage.isActiveMiniGame,
                     coinTossMaxBettingPoint = dto.miniGame.coinToss.maxBettingPoint,
                     coinTossMinBettingPoint = dto.miniGame.coinToss.maxBettingPoint,
+                    coinTossInitialTicketCount = dto.miniGame.coinToss.initialTicketCount,
                 )
             )
         )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -83,6 +83,18 @@ class StageValidator(
         if (dto.shop.plinko.isActive && (dto.shop.plinko.price == null || dto.shop.plinko.quantity == null)) {
             throw StageException("Plinko 미니게임의 티켓 가격, 수량을 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
+
+        if (dto.miniGame.coinToss.isActive.not() && dto.shop.coinToss.isActive) {
+            throw StageException("CoinToss 미니게임을 활성화 하지않은 상태에서 상점을 활성화 할 수 없습니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.miniGame.yavarwee.isActive.not() && dto.shop.yavarwee.isActive) {
+            throw StageException("Yavarwee 미니게임을 활성화 하지않은 상태에서 상점을 활성화 할 수 없습니다.", HttpStatus.BAD_REQUEST.value())
+        }
+
+        if (dto.miniGame.plinko.isActive.not() && dto.shop.plinko.isActive) {
+            throw StageException("Plinko 미니게임을 활성화 하지않은 상태에서 상점을 활성화 할 수 없습니다.", HttpStatus.BAD_REQUEST.value())
+        }
     }
 
     private fun validMiniGame(dto: CreateOfficialStageDto) {

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/StageValidator.kt
@@ -24,8 +24,8 @@ class StageValidator(
             throw StageException("스테이지 관리자는 최대 5명까지 가능합니다.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.miniGame.coinToss.isActive && dto.miniGame.coinToss.maxBettingPoint == null) {
-            throw StageException("CoinToss 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        if (dto.miniGame.coinToss.isActive && (dto.miniGame.coinToss.maxBettingPoint == null || dto.miniGame.coinToss.initialTicketCount == null)) {
+            throw StageException("CoinToss 미니게임의 최대 배팅 포인트, 초기 보유 티켓 개수를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
     }
 
@@ -86,16 +86,16 @@ class StageValidator(
     }
 
     private fun validMiniGame(dto: CreateOfficialStageDto) {
-        if (dto.miniGame.coinToss.isActive && (dto.miniGame.coinToss.maxBettingPoint == null)) {
-            throw StageException("CoinToss 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        if (dto.miniGame.coinToss.isActive && (dto.miniGame.coinToss.maxBettingPoint == null || dto.miniGame.coinToss.initialTicketCount == null)) {
+            throw StageException("CoinToss 미니게임의 최대 배팅 포인트, 초기 보유 티켓 개수를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.miniGame.yavarwee.isActive && (dto.miniGame.yavarwee.maxBettingPoint == null)) {
-            throw StageException("Yavarwee 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        if (dto.miniGame.yavarwee.isActive && (dto.miniGame.yavarwee.maxBettingPoint == null || dto.miniGame.yavarwee.initialTicketCount == null)) {
+            throw StageException("Yavarwee 미니게임의 최대 배팅 포인트, 초기 보유 티켓 개수를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
 
-        if (dto.miniGame.plinko.isActive && (dto.miniGame.plinko.maxBettingPoint == null)) {
-            throw StageException("Plinko 미니게임의 최대 배팅 포인트를 입력하세요.", HttpStatus.BAD_REQUEST.value())
+        if (dto.miniGame.plinko.isActive && (dto.miniGame.plinko.maxBettingPoint == null || dto.miniGame.plinko.initialTicketCount == null)) {
+            throw StageException("Plinko 미니게임의 최대 배팅 포인트, 초기 보유 티켓 개수를 입력하세요.", HttpStatus.BAD_REQUEST.value())
         }
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
@@ -98,6 +98,7 @@ data class MiniGameInfoDto(
     val isActive: Boolean,
     val maxBettingPoint: Long?,
     val minBettingPoint: Long?,
+    val initialTicketCount: Int?
 )
 
 data class StageJoinDto(

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageFastEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageFastEvent.kt
@@ -10,4 +10,5 @@ data class FastStageMiniGameDto(
     val isCoinTossActive: Boolean,
     val coinTossMaxBettingPoint: Long?,
     val coinTossMinBettingPoint: Long?,
+    val coinTossInitialTicketCount: Int?
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/event/CreateStageOfficialEvent.kt
@@ -28,4 +28,5 @@ data class OfficialStageMiniGameInfoDto(
     val isActive: Boolean,
     val maxBettingPoint: Long?,
     val minBettingPoint: Long?,
+    val initialTicketCount: Int?,
 )


### PR DESCRIPTION
## 개요
스테이지 생성 관련 로직을 수정하였습니다.

## 본문
- 스테이지 생성시 누락되어있던 `initialTicketCount` - 미니게임 초기 보유 티켓 개수 필드를 추가하였습니다. (reqeust, event)
- Maintainer 생성시 중복을 없애고 본인이 관리자로 중복 등록되는 경우를 체크했습니다.
- 미니게임이 활성화 되지 않았는데 상점을 활성화 하는 경우를 체크했습니다.