### PR TITLE
[stage] 매치 검색하기 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchMapper.kt
@@ -1,14 +1,15 @@
 package gogo.gogostage.domain.match.root.application
 
-import gogo.gogostage.domain.match.root.application.dto.MatchApiInfoDto
-import gogo.gogostage.domain.match.root.application.dto.StageApiInfoDto
+import gogo.gogostage.domain.match.root.application.dto.*
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.stage.maintainer.persistence.StageMaintainerRepository
+import gogo.gogostage.global.internal.betting.api.BettingApi
 import org.springframework.stereotype.Component
 
 @Component
 class MatchMapper(
-    private val maintainerRepository: StageMaintainerRepository
+    private val maintainerRepository: StageMaintainerRepository,
+    private val bettingApi: BettingApi
 ) {
 
     fun mapInfo(match: Match): MatchApiInfoDto {
@@ -23,6 +24,70 @@ class MatchMapper(
                 maintainers = maintainers.map { it.studentId }
             )
         )
+    }
+
+    fun mapSearch(matches: List<Match>, studentId: Long): MatchSearchDto {
+        val matchIds = matches.map { it.id }
+        val bundleDto = bettingApi.bundle(matchIds, studentId)
+
+        val matchInfoList = matches.map { matchEntity ->
+            val bettingInfo = bundleDto.bettings.find { it.matchId == matchEntity.id }
+            val resultInfo = bettingInfo?.result?.let {
+                MatchResultInfoDto(
+                    victoryTeamId = matchEntity.matchResult!!.victoryTeam.id,
+                    aTeamScore = matchEntity.matchResult!!.aTeamScore,
+                    bTeamScore = matchEntity.matchResult!!.bTeamScore,
+                    isPredictionSuccess = it.isPredicted,
+                    earnedPoint = it.earnedPoint
+                )
+            } ?: matchEntity.matchResult?.let {
+                MatchResultInfoDto(
+                    victoryTeamId = it.victoryTeam.id,
+                    aTeamScore = it.aTeamScore,
+                    bTeamScore = it.bTeamScore,
+                    isPredictionSuccess = null,
+                    earnedPoint = null
+                )
+            }
+
+            MatchInfoDto(
+                matchId = matchEntity.id,
+                aTeam = MatchTeamInfoDto(
+                    teamId = matchEntity.aTeam?.id,
+                    teamName = if (matchEntity.aTeam != null) matchEntity.aTeam!!.name else "TBD",
+                    bettingPoint = matchEntity.aTeamBettingPoint,
+                    winCount = matchEntity.aTeam?.winCount
+                ),
+                bTeam = MatchTeamInfoDto(
+                    teamId = matchEntity.bTeam?.id,
+                    teamName = if (matchEntity.bTeam != null) matchEntity.bTeam!!.name else "TBD",
+                    bettingPoint = matchEntity.bTeamBettingPoint,
+                    winCount = matchEntity.bTeam?.winCount
+                ),
+                startDate = matchEntity.startDate,
+                endDate = matchEntity.endDate,
+                isEnd = matchEntity.isEnd,
+                round = matchEntity.round,
+                category = matchEntity.game.category,
+                gameName = matchEntity.game.name,
+                system = matchEntity.game.system,
+                turn = matchEntity.turn,
+                betting = bettingInfo?.let {
+                    MatchBettingInfoDto(
+                        isBetting = true,
+                        bettingPoint = it.betting.bettingPoint,
+                        predictedWinTeamId = it.betting.predictedWinTeamId
+                    )
+                } ?: MatchBettingInfoDto(
+                    isBetting = false,
+                    bettingPoint = null,
+                    predictedWinTeamId = null
+                ),
+                result = resultInfo
+            )
+        }
+
+        return MatchSearchDto(count = matchInfoList.size, matches = matchInfoList)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
@@ -1,5 +1,7 @@
 package gogo.gogostage.domain.match.root.application
 
+import gogo.gogostage.domain.match.root.application.dto.MatchInfoDto
+import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.global.error.StageException
@@ -15,5 +17,8 @@ class MatchReader(
     fun read(matchId: Long): Match =
         matchRepository.findByIdOrNull(matchId)
             ?: throw StageException("Match not found, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
+
+    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto =
+        matchRepository.search(stageId, studentId, y, m, d)
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
@@ -1,7 +1,5 @@
 package gogo.gogostage.domain.match.root.application
 
-import gogo.gogostage.domain.match.root.application.dto.MatchInfoDto
-import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.global.error.StageException
@@ -18,7 +16,7 @@ class MatchReader(
         matchRepository.findByIdOrNull(matchId)
             ?: throw StageException("Match not found, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
 
-    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto =
+    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): List<Match> =
         matchRepository.search(stageId, studentId, y, m, d)
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchService.kt
@@ -1,7 +1,9 @@
 package gogo.gogostage.domain.match.root.application
 
 import gogo.gogostage.domain.match.root.application.dto.MatchApiInfoDto
+import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
 
 interface MatchService {
     fun matchApiInfo(matchId: Long): MatchApiInfoDto
+    fun search(stageId: Long, y: Int, m: Int, d: Int): MatchSearchDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
@@ -1,19 +1,31 @@
 package gogo.gogostage.domain.match.root.application
 
 import gogo.gogostage.domain.match.root.application.dto.MatchApiInfoDto
+import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
+import gogo.gogostage.domain.stage.root.application.StageValidator
+import gogo.gogostage.global.util.UserContextUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MatchServiceImpl(
     private val matchReader: MatchReader,
-    private val matchMapper: MatchMapper
+    private val matchMapper: MatchMapper,
+    private val userUtil: UserContextUtil,
+    private val stageValidator: StageValidator
 ) : MatchService {
 
     @Transactional(readOnly = true)
     override fun matchApiInfo(matchId: Long): MatchApiInfoDto {
         val match = matchReader.read(matchId)
         return matchMapper.mapInfo(match)
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(stageId: Long, y: Int, m: Int, d: Int): MatchSearchDto {
+        val student = userUtil.getCurrentStudent()
+        stageValidator.validStage(student, stageId)
+        return matchReader.search(stageId, student.studentId, y, m, d)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
@@ -25,7 +25,8 @@ class MatchServiceImpl(
     override fun search(stageId: Long, y: Int, m: Int, d: Int): MatchSearchDto {
         val student = userUtil.getCurrentStudent()
         stageValidator.validStage(student, stageId)
-        return matchReader.search(stageId, student.studentId, y, m, d)
+        val matches = matchReader.search(stageId, student.studentId, y, m, d)
+        return matchMapper.mapSearch(matches, student.studentId)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -1,5 +1,8 @@
 package gogo.gogostage.domain.match.root.application.dto
 
+import gogo.gogostage.domain.game.persistence.GameCategory
+import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.match.root.persistence.Round
 import java.time.LocalDateTime
 
 data class MatchApiInfoDto(
@@ -10,4 +13,46 @@ data class MatchApiInfoDto(
 
 data class StageApiInfoDto(
     val maintainers: List<Long>
+)
+
+data class MatchSearchDto(
+    val count: Int,
+    val matches: List<MatchInfoDto>
+)
+
+data class MatchInfoDto(
+    val matchId: Long,
+    val aTeam: MatchTeamInfoDto,
+    val bTeam: MatchTeamInfoDto,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime,
+    val isEnd: Boolean,
+    val round: Round?,
+    val category: GameCategory,
+    val gameName: String,
+    val system: GameSystem,
+    val turn: Int?,
+    val betting: MatchBettingInfoDto?,
+    val result: MatchResultInfoDto?
+)
+
+data class MatchTeamInfoDto(
+    val teamId: Long,
+    val teamName: String,
+    val bettingPoint: Long,
+    val winCount: Int,
+)
+
+data class MatchBettingInfoDto(
+    val isBetting: Boolean,
+    val bettingPoint: Long?,
+    val predictedWinTeamId: Long?,
+)
+
+data class MatchResultInfoDto(
+    val victoryTeamId: Long,
+    val aTeamScore: Int,
+    val bTeamScore: Int,
+    val isPredictionSuccess: Boolean?,
+    val earnedPoint: Long?
 )

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -37,14 +37,14 @@ data class MatchInfoDto(
 )
 
 data class MatchTeamInfoDto(
-    val teamId: Long,
+    val teamId: Long?,
     val teamName: String,
-    val bettingPoint: Long,
-    val winCount: Int,
+    val bettingPoint: Long?,
+    val winCount: Int?,
 )
 
 data class MatchBettingInfoDto(
-    val isBetting: Boolean,
+    val isBetting: Boolean?,
     val bettingPoint: Long?,
     val predictedWinTeamId: Long?,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/Match.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.match.root.persistence
 
 import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.match.result.persistence.MatchResult
 import gogo.gogostage.domain.team.root.persistence.Team
 import gogo.gogostage.global.error.StageException
 import jakarta.persistence.*
@@ -51,6 +52,9 @@ class Match(
 
     @Column(name = "b_team_betting_point", nullable = false)
     var bTeamBettingPoint: Long = 0,
+
+    @OneToOne(mappedBy = "match", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val matchResult: MatchResult? = null
 ) {
 
     companion object {

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepository.kt
@@ -1,7 +1,6 @@
 package gogo.gogostage.domain.match.root.persistence
 
-import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
 
 interface MatchCustomRepository {
-    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto
+    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): List<Match>
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepository.kt
@@ -1,0 +1,7 @@
+package gogo.gogostage.domain.match.root.persistence
+
+import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
+
+interface MatchCustomRepository {
+    fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepositoryImpl.kt
@@ -1,99 +1,33 @@
 package gogo.gogostage.domain.match.root.persistence
 
-import com.querydsl.core.types.Projections
-import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.JPQLQueryFactory
-import gogo.gogostage.domain.match.root.application.dto.*
+import gogo.gogostage.domain.game.persistence.QGame.*
+import gogo.gogostage.domain.match.result.persistence.QMatchResult.*
 import gogo.gogostage.domain.match.root.persistence.QMatch.*
-import gogo.gogostage.domain.stage.root.persistence.QStage.stage
-import gogo.gogostage.global.internal.betting.api.BettingApi
+import gogo.gogostage.domain.stage.root.persistence.QStage.*
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
 @Repository
 class MatchCustomRepositoryImpl(
     private val queryFactory: JPQLQueryFactory,
-    private val bettingApi: BettingApi,
+) : MatchCustomRepository {
 
-    ) : MatchCustomRepository {
-
-    override fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto {
-        val matches = queryFactory.select(
-            Projections.constructor(
-                MatchInfoDto::class.java,
-                match.id,
-                Projections.constructor(
-                    MatchTeamInfoDto::class.java,
-                    match.aTeam.id,
-                    match.aTeam.name,
-                    match.aTeamBettingPoint,
-                    match.aTeam.winCount
-                ),
-                Projections.constructor(
-                    MatchTeamInfoDto::class.java,
-                    match.bTeam.id,
-                    match.bTeam.name,
-                    match.bTeamBettingPoint,
-                    match.bTeam.winCount
-                ),
-                match.startDate,
-                match.endDate,
-                match.isEnd,
-                match.round,
-                match.game.category,
-                match.game.name,
-                match.game.system,
-                match.turn,
-                null, // betting 필드 (이후 업데이트)
-                Projections.constructor(
-                    MatchResultInfoDto::class.java,
-                    match.matchResult.victoryTeam.id,
-                    match.matchResult.aTeamScore,
-                    match.matchResult.bTeamScore,
-                    null,
-                    null
-                )
+    override fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): List<Match> =
+        queryFactory
+            .selectFrom(match)
+            .leftJoin(match.matchResult, matchResult).fetchJoin()
+            .join(match.game, game).fetchJoin()
+            .join(game.stage, stage).fetchJoin()
+            .leftJoin(match.aTeam).fetchJoin()
+            .leftJoin(match.bTeam).fetchJoin()
+            .where(
+                stage.id.eq(stageId)
+                    .and(match.startDate.between(
+                        LocalDate.of(y, m, d).atStartOfDay(),
+                        LocalDate.of(y, m, d).atTime(23, 59, 59)
+                    ))
             )
-        )
-        .from(match)
-        .where(
-            match.game.stage.id.eq(stage.id)
-                .and(
-                    Expressions.dateTemplate(
-                        LocalDate::class.java, "DATE({0})", match.startDate
-                    ).eq(LocalDate.of(y, m, d))
-                )
-        ).fetch()
-
-        val matchIds = matches.map { it.matchId }
-        val bundleDto = bettingApi.bundle(matchIds, studentId)
-
-        val matchMap = matches.associateBy { it.matchId }.toMutableMap()
-
-        bundleDto.bettings.forEach { bettingInfo ->
-            matchMap[bettingInfo.matchId]?.let { matchInfo ->
-                matchMap[bettingInfo.matchId] = matchInfo.copy(
-                    betting = MatchBettingInfoDto(
-                        isBetting = true,
-                        bettingPoint = bettingInfo.betting.bettingPoint,
-                        predictedWinTeamId = bettingInfo.betting.predictedWinTeamId
-                    ),
-                    result = bettingInfo.result?.let {
-                        MatchResultInfoDto(
-                            victoryTeamId = matchInfo.result!!.victoryTeamId,
-                            aTeamScore = matchInfo.result!!.aTeamScore,
-                            bTeamScore = matchInfo.result!!.bTeamScore,
-                            isPredictionSuccess = it.isPredicted,
-                            earnedPoint = it.earnedPoint
-                        )
-                    } ?: matchInfo.result
-                )
-            }
-        }
-
-        val updatedMatches = matchMap.values.toList()
-
-        return MatchSearchDto(count = updatedMatches.size, matches = updatedMatches)
-    }
+            .fetch()
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchCustomRepositoryImpl.kt
@@ -1,0 +1,99 @@
+package gogo.gogostage.domain.match.root.persistence
+
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.jpa.JPQLQueryFactory
+import gogo.gogostage.domain.match.root.application.dto.*
+import gogo.gogostage.domain.match.root.persistence.QMatch.*
+import gogo.gogostage.domain.stage.root.persistence.QStage.stage
+import gogo.gogostage.global.internal.betting.api.BettingApi
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class MatchCustomRepositoryImpl(
+    private val queryFactory: JPQLQueryFactory,
+    private val bettingApi: BettingApi,
+
+    ) : MatchCustomRepository {
+
+    override fun search(stageId: Long, studentId: Long, y: Int, m: Int, d: Int): MatchSearchDto {
+        val matches = queryFactory.select(
+            Projections.constructor(
+                MatchInfoDto::class.java,
+                match.id,
+                Projections.constructor(
+                    MatchTeamInfoDto::class.java,
+                    match.aTeam.id,
+                    match.aTeam.name,
+                    match.aTeamBettingPoint,
+                    match.aTeam.winCount
+                ),
+                Projections.constructor(
+                    MatchTeamInfoDto::class.java,
+                    match.bTeam.id,
+                    match.bTeam.name,
+                    match.bTeamBettingPoint,
+                    match.bTeam.winCount
+                ),
+                match.startDate,
+                match.endDate,
+                match.isEnd,
+                match.round,
+                match.game.category,
+                match.game.name,
+                match.game.system,
+                match.turn,
+                null, // betting 필드 (이후 업데이트)
+                Projections.constructor(
+                    MatchResultInfoDto::class.java,
+                    match.matchResult.victoryTeam.id,
+                    match.matchResult.aTeamScore,
+                    match.matchResult.bTeamScore,
+                    null,
+                    null
+                )
+            )
+        )
+        .from(match)
+        .where(
+            match.game.stage.id.eq(stage.id)
+                .and(
+                    Expressions.dateTemplate(
+                        LocalDate::class.java, "DATE({0})", match.startDate
+                    ).eq(LocalDate.of(y, m, d))
+                )
+        ).fetch()
+
+        val matchIds = matches.map { it.matchId }
+        val bundleDto = bettingApi.bundle(matchIds, studentId)
+
+        val matchMap = matches.associateBy { it.matchId }.toMutableMap()
+
+        bundleDto.bettings.forEach { bettingInfo ->
+            matchMap[bettingInfo.matchId]?.let { matchInfo ->
+                matchMap[bettingInfo.matchId] = matchInfo.copy(
+                    betting = MatchBettingInfoDto(
+                        isBetting = true,
+                        bettingPoint = bettingInfo.betting.bettingPoint,
+                        predictedWinTeamId = bettingInfo.betting.predictedWinTeamId
+                    ),
+                    result = bettingInfo.result?.let {
+                        MatchResultInfoDto(
+                            victoryTeamId = matchInfo.result!!.victoryTeamId,
+                            aTeamScore = matchInfo.result!!.aTeamScore,
+                            bTeamScore = matchInfo.result!!.bTeamScore,
+                            isPredictionSuccess = it.isPredicted,
+                            earnedPoint = it.earnedPoint
+                        )
+                    } ?: matchInfo.result
+                )
+            }
+        }
+
+        val updatedMatches = matchMap.values.toList()
+
+        return MatchSearchDto(count = updatedMatches.size, matches = updatedMatches)
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -3,7 +3,7 @@ package gogo.gogostage.domain.match.root.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface MatchRepository: JpaRepository<Match, Long> {
+interface MatchRepository: JpaRepository<Match, Long>, MatchCustomRepository {
     @Query("SELECT m FROM Match m WHERE m.id = :matchId AND m.isEnd = false")
     fun findNotEndMatchById(matchId: Long): Match?
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/presentation/MatchController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/presentation/MatchController.kt
@@ -2,11 +2,11 @@ package gogo.gogostage.domain.match.root.presentation
 
 import gogo.gogostage.domain.match.root.application.MatchService
 import gogo.gogostage.domain.match.root.application.dto.MatchApiInfoDto
+import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotNull
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/stage")
@@ -19,6 +19,17 @@ class MatchController(
         @RequestParam matchId: Long
     ): ResponseEntity<MatchApiInfoDto> {
         val response = matchService.matchApiInfo(matchId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/match/search/{stage_id}")
+    fun search(
+        @PathVariable("stage_id") stageId: Long,
+        @RequestParam @Valid @NotNull y: Int,
+        @RequestParam @Valid @NotNull m: Int,
+        @RequestParam @Valid @NotNull d: Int,
+    ): ResponseEntity<MatchSearchDto> {
+        val response = matchService.search(stageId, y, m, d)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -52,7 +52,9 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/join/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/team/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/confirm/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
-            httpRequests.requestMatchers(HttpMethod.POST, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+
+            // match
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // community
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -52,7 +52,8 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/join/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/team/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/confirm/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
-            
+            httpRequests.requestMatchers(HttpMethod.POST, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+
             // community
             httpRequests.requestMatchers(HttpMethod.POST, "/stage/community/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/community/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)

--- a/src/main/kotlin/gogo/gogostage/global/feign/client/BettingClient.kt
+++ b/src/main/kotlin/gogo/gogostage/global/feign/client/BettingClient.kt
@@ -1,0 +1,15 @@
+package gogo.gogostage.global.feign.client
+
+import gogo.gogostage.global.internal.betting.stub.BettingBundleDto
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(name = "gogo-betting")
+interface BettingClient {
+    @GetMapping("/betting/bundle")
+    fun bundle(
+        @RequestParam("matchIds") matchIds: List<Long>,
+        @RequestParam("studentId") studentId: Long
+    ): BettingBundleDto
+}

--- a/src/main/kotlin/gogo/gogostage/global/internal/betting/api/BettingApi.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/betting/api/BettingApi.kt
@@ -1,0 +1,7 @@
+package gogo.gogostage.global.internal.betting.api
+
+import gogo.gogostage.global.internal.betting.stub.BettingBundleDto
+
+interface BettingApi {
+    fun bundle(matchIds: List<Long>, studentId: Long): BettingBundleDto
+}

--- a/src/main/kotlin/gogo/gogostage/global/internal/betting/api/BettingApiImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/betting/api/BettingApiImpl.kt
@@ -1,0 +1,15 @@
+package gogo.gogostage.global.internal.betting.api
+
+import gogo.gogostage.global.feign.client.BettingClient
+import gogo.gogostage.global.internal.betting.stub.BettingBundleDto
+import org.springframework.stereotype.Component
+
+@Component
+class BettingApiImpl(
+    private val bettingClient: BettingClient,
+) : BettingApi {
+
+    override fun bundle(matchIds: List<Long>, studentId: Long): BettingBundleDto =
+        bettingClient.bundle(matchIds, studentId)
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/internal/betting/stub/BettingStub.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/betting/stub/BettingStub.kt
@@ -1,0 +1,22 @@
+package gogo.gogostage.global.internal.betting.stub
+
+data class BettingBundleDto(
+    val bettings: List<BettingBundleInfoDto>
+)
+
+data class BettingBundleInfoDto(
+    val matchId: Long,
+    val betting: BettingInfoDto,
+    val result: BettingResultInfoDto?
+)
+
+data class BettingInfoDto(
+    val bettingId: Long,
+    val bettingPoint: Long,
+    val predictedWinTeamId: Long,
+)
+
+data class BettingResultInfoDto(
+    val isPredicted: Boolean,
+    val earnedPoint: Long,
+)


### PR DESCRIPTION
## 개요
매치 검색하기 API를 개발하였습니다.

## 본문
- StageValidator로 요청을 보낸 사용자가 해당 스테이지에 참여하고 있는지 검증합니다.
- stageId, y, m, d를 받아 매치를 검색하고 해당 유저의 배팅 정보를 Betting 서비스에서 rest 통신을 통해 일괄적으로 받아옵니다.