### PR TITLE
[stage] MiniGame 서비스 미니게임 완료 이벤트 핸들링

### DIFF
--- a/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/configuration/KafkaConsumerConfig.kt
@@ -17,6 +17,10 @@ class KafkaConsumerConfig(
 ) {
 
     @Bean
+    fun miniGameBetCompletedEventListenerContainerFactory(listener: MiniGameBetCompletedConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
+        makeFactory(listener)
+
+    @Bean
     fun ticketAdditionFailedEventListenerContainerFactory(listener: TicketAdditionFailedConsumer): ConcurrentKafkaListenerContainerFactory<String, String> =
         makeFactory(listener)
 

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MiniGameBetCompletedConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MiniGameBetCompletedConsumer.kt
@@ -1,0 +1,55 @@
+package gogo.gogostage.global.kafka.consumer
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import gogo.gogostage.domain.stage.participant.root.application.ParticipateProcessor
+import gogo.gogostage.global.kafka.consumer.dto.MiniGameBetCompletedEvent
+import gogo.gogostage.global.kafka.consumer.dto.MiniGameBetCompletedFailedEvent
+import gogo.gogostage.global.kafka.properties.KafkaTopics.MINIGAME_BET_COMPLETED
+import gogo.gogostage.global.kafka.publisher.StagePublisher
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.listener.AcknowledgingMessageListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class MiniGameBetCompletedConsumer(
+    private val objectMapper: ObjectMapper,
+    private val stagePublisher: StagePublisher,
+    private val stageParticipateProcessor: ParticipateProcessor
+) : AcknowledgingMessageListener<String, String> {
+
+    private val log = LoggerFactory.getLogger(this::class.java.simpleName)
+
+    @KafkaListener(
+        topics = [MINIGAME_BET_COMPLETED],
+        groupId = "gogo",
+        containerFactory = "batchCancelEventListenerContainerFactory"
+    )
+    override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
+        val (key, event) = data.key() to objectMapper.readValue(data.value(), MiniGameBetCompletedEvent::class.java)
+        log.info("${MINIGAME_BET_COMPLETED}_topic, key: $key, event: $event")
+
+        try {
+
+            stageParticipateProcessor.minigameBetting(event)
+
+        } catch (e: Exception) {
+            log.error("Failed to MiniGame Bet Completed, Stage Id = ${event.stageId}, MiniGame Type = ${event.gameType}, Student Id = ${event.studentId}", e)
+
+            stagePublisher.publishMiniGameBetCompletedFailedEvent(
+                MiniGameBetCompletedFailedEvent(
+                    id = UUID.randomUUID().toString(),
+                    stageId = event.stageId,
+                    studentId = event.studentId,
+                    gameType = event.gameType,
+                ),
+            )
+        }
+
+        acknowledgment!!.acknowledge()
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MiniGameBetCompletedConsumer.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/MiniGameBetCompletedConsumer.kt
@@ -26,7 +26,7 @@ class MiniGameBetCompletedConsumer(
     @KafkaListener(
         topics = [MINIGAME_BET_COMPLETED],
         groupId = "gogo",
-        containerFactory = "batchCancelEventListenerContainerFactory"
+        containerFactory = "miniGameBetCompletedEventListenerContainerFactory"
     )
     override fun onMessage(data: ConsumerRecord<String, String>, acknowledgment: Acknowledgment?) {
         val (key, event) = data.key() to objectMapper.readValue(data.value(), MiniGameBetCompletedEvent::class.java)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MiniGameBetCompletedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MiniGameBetCompletedEvent.kt
@@ -1,0 +1,15 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class MiniGameBetCompletedEvent(
+    val id: String,
+    val earnedPoint: Long,
+    val lostedPoint: Long,
+    val isWin: Boolean,
+    val studentId: Long,
+    val stageId: Long,
+    val gameType: MiniGameType
+)
+
+enum class MiniGameType {
+    YAVARWEE, PLINKO, COINTOSS
+}

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MiniGameBetCompletedFailedEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MiniGameBetCompletedFailedEvent.kt
@@ -1,0 +1,8 @@
+package gogo.gogostage.global.kafka.consumer.dto
+
+data class MiniGameBetCompletedFailedEvent(
+    val id: String,
+    val studentId: Long,
+    val stageId: Long,
+    val gameType: MiniGameType
+)

--- a/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/properties/KafkaTopics.kt
@@ -14,4 +14,6 @@ object KafkaTopics {
     const val STAGE_CREATE_OFFICIAL = "stage_create_official"
     const val STAGE_CREATE_FAST = "stage_create_fast"
     const val STAGE_CONFIRM = "stage_confirm"
+    const val MINIGAME_BET_COMPLETED = "minigame_bet_completed"
+    const val MINIGAME_BET_COMPLETED_FAILED = "minigame_bet_completed_failed"
 }

--- a/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/publisher/StagePublisher.kt
@@ -4,15 +4,13 @@ import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageFastEvent
 import gogo.gogostage.domain.stage.root.event.CreateStageOfficialEvent
 import gogo.gogostage.domain.stage.root.event.StageConfirmEvent
-import gogo.gogostage.global.kafka.consumer.dto.BatchAdditionTempPointFailedEvent
-import gogo.gogostage.global.kafka.consumer.dto.BatchCancelDeleteTempPointFailedEvent
-import gogo.gogostage.global.kafka.consumer.dto.MatchBettingFailedEvent
-import gogo.gogostage.global.kafka.consumer.dto.TicketPointMinusFailedEvent
+import gogo.gogostage.global.kafka.consumer.dto.*
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_ADDITION_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.BATCH_CANCEL_DELETE_TEMP_POINT_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CREATE_OFFICIAL
 import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CREATE_FAST
 import gogo.gogostage.global.kafka.properties.KafkaTopics.MATCH_BETTING_FAILED
+import gogo.gogostage.global.kafka.properties.KafkaTopics.MINIGAME_BET_COMPLETED_FAILED
 import gogo.gogostage.global.kafka.properties.KafkaTopics.STAGE_CONFIRM
 import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS
 import gogo.gogostage.global.kafka.properties.KafkaTopics.TICKET_POINT_MINUS_FAILED
@@ -108,6 +106,17 @@ class StagePublisher(
         val key = UUID.randomUUID().toString()
         transactionEventPublisher.publishEvent(
             topic = TICKET_POINT_MINUS_FAILED,
+            key = key,
+            event = event
+        )
+    }
+
+    fun publishMiniGameBetCompletedFailedEvent(
+        event: MiniGameBetCompletedFailedEvent
+    ) {
+        val key = UUID.randomUUID().toString()
+        transactionEventPublisher.publishEvent(
+            topic = MINIGAME_BET_COMPLETED_FAILED,
             key = key,
             event = event
         )


### PR DESCRIPTION
## 개요
MiniGame 서비스 미니게임 완료 이벤트 핸들링 작업을 구현하였습니다.

## 본문
- `minigame_bet_completed` 토픽에서 이벤트를 컨슘하여 유저의 포인트를 추가하거나 깎습니다.
- 해당 작업 중 예외가 발생시 `minigame_bet_completed_failed` 토픽에 이벤트를 발행하여 해당 미니게임 롤백을 기대합니다.