### PR TITLE
[stage] 커뮤니티 게시글 상세조회 반환되지 않는 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -123,7 +123,7 @@ class CommunityCustomRepositoryImpl(
             .where(predicate)
             .fetch()
 
-        val studentIds = comments.map { it.studentId }
+        val studentIds = comments.map { it.studentId }.toSet().toList()
 
         val commentLikeIds = queryFactory.select(commentLike.id)
             .from(commentLike)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -123,10 +123,7 @@ class CommunityCustomRepositoryImpl(
             .where(predicate)
             .fetch()
 
-        val studentIds = queryFactory.select(comment.studentId)
-            .from(comment)
-            .where(comment.board.id.eq(boardId))
-            .fetch()
+        val studentIds = comments.map { it.studentId }
 
         val commentLikeIds = queryFactory.select(commentLike.id)
             .from(commentLike)
@@ -135,7 +132,7 @@ class CommunityCustomRepositoryImpl(
             ))
             .fetch()
 
-        val commentStudents = studentApi.queryByStudentsIds(studentIds.toSet().toList())
+        val commentStudents = studentApi.queryByStudentsIds(studentIds)
 
         val commentDto = comments.map { comment ->
             val author = commentStudents.students.find { it.studentId == comment.studentId }?.let {


### PR DESCRIPTION
# 개요
커뮤니티 게시글 상세조회가 status Code만 반횐이 되고 바디가 오지 않는 문제가 생겨 해결하였습니다

# 본문
문제 상황 파악 중 AuthorDto를 만드는 과정에서 NPE가 발생하는 상황이 발생하여 StudentIds를 추출하는 방식을 변경하여 해결하였습니다.
정확히 파악은 되지 않았지만 테스트 결과 성공하였습니다.

<img width="875" alt="스크린샷 2025-03-25 오전 11 20 46" src="https://github.com/user-attachments/assets/3fde4a22-658c-47f2-8d26-0d970058f401" />
