### PR TITLE
[stage] 커뮤니티 게시글 조회 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -86,11 +86,7 @@ class CommunityCustomRepositoryImpl(
 
         val totalElement = boardDtoList.size
 
-        val totalPage = if (totalElement % size == 0) {
-            totalElement / size
-        } else {
-            totalElement / size + 1
-        }
+        val totalPage = boardRepository.findAll(pageable).totalPages
 
         val infoDto = InfoDto(totalPage, totalElement)
 


### PR DESCRIPTION
# 개요
커뮤니티 게시글을 조회할 때 totalPage가 정확하게 나오지 않는 문제를 해결하였습니다.

# 본문
직접 totalPage를 구하는 로직의 문제가 생겨 findAll(pageable).totalPages 를 사용하여 totalPage를 구하는 로직으로 변경하였습니다

# 예시
<img width="880" alt="스크린샷 2025-03-25 오후 5 53 30" src="https://github.com/user-attachments/assets/65cbfcc0-4e40-4d07-bb8a-bc22e27ddd08" />

<img width="882" alt="스크린샷 2025-03-25 오후 5 53 38" src="https://github.com/user-attachments/assets/0b96cab3-e5a3-417a-a23c-a4e0805daef1" />
