### PR TITLE
[stage] 커뮤니티 게시글/댓글 좋아요 반환 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
@@ -26,7 +26,7 @@ class Board(
     val content: String,
 
     @Column(name = "comment_count", nullable = false)
-    val commentCount: Int,
+    var commentCount: Int,
 
     @Column(name = "like_count", nullable = false)
     var likeCount: Int,
@@ -44,6 +44,10 @@ class Board(
 
     fun plusLikeCount() {
         likeCount += 1
+    }
+
+    fun plusCommentCount() {
+        commentCount += 1
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -73,6 +73,9 @@ class CommunityProcessor(
 
         commentRepository.save(comment)
 
+        board.plusCommentCount()
+        boardRepository.save(board)
+
         return commentMapper.mapWriteBoardCommentResDto(comment, writeBoardCommentDto, student)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -9,6 +9,7 @@ import gogo.gogostage.domain.community.root.persistence.CommunityRepository
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.global.error.StageException
+import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
@@ -29,8 +30,8 @@ class CommunityReader(
         return communityRepository.searchCommunityBoardPage(stageId, size, category, sort, pageRequest)
     }
 
-    fun readBoardInfo(boardId: Long): GetCommunityBoardInfoResDto =
-        communityRepository.getCommunityBoardInfo(boardId)
+    fun readBoardInfo(boardId: Long, student: StudentByIdStub): GetCommunityBoardInfoResDto =
+        communityRepository.getCommunityBoardInfo(boardId, student)
 
     fun readBoardByBoardId(boardId: Long) =
         boardReader.read(boardId)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -49,7 +49,6 @@ class CommunityServiceImpl(
     override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
-        board.plusCommentCount()
         // 욕설 필터링 필요
         return communityProcessor.saveBoardComment(student, writeBoardCommentDto, board)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -49,6 +49,7 @@ class CommunityServiceImpl(
     override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
+        board.plusCommentCount()
         // 욕설 필터링 필요
         return communityProcessor.saveBoardComment(student, writeBoardCommentDto, board)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -34,7 +34,8 @@ class CommunityServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto {
-        return communityReader.readBoardInfo(boardId)
+        val student = userUtil.getCurrentStudent()
+        return communityReader.readBoardInfo(boardId, student)
     }
 
     @Transactional

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -34,6 +34,7 @@ data class BoardDto(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val createdAt: LocalDateTime,
     val stageType: StageType,
+    val commentCount: Int,
     val author: AuthorDto
 )
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -3,9 +3,10 @@ package gogo.gogostage.domain.community.root.persistence
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.game.persistence.GameCategory
+import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.data.domain.Pageable
 
 interface CommunityCustomRepository {
     fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
-    fun getCommunityBoardInfo(boardId: Long): GetCommunityBoardInfoResDto
+    fun getCommunityBoardInfo(boardId: Long, student: StudentByIdStub): GetCommunityBoardInfoResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -111,7 +111,7 @@ class CommunityCustomRepositoryImpl(
 
         val predicate = BooleanBuilder()
 
-        predicate.and(QBoard.board.id.eq(comment.board.id))
+        predicate.and(comment.board.id.eq(boardId))
 
         val comments = queryFactory.selectFrom(comment)
             .where(predicate)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -82,6 +82,7 @@ class CommunityCustomRepositoryImpl(
                 likeCount = board.likeCount,
                 createdAt = board.createdAt,
                 stageType = board.community.stage.type,
+                commentCount = board.commentCount,
                 author = author!!
             )
         }.toList()


### PR DESCRIPTION
# 개요
게시글 상세보기에서 게시글/댓글의 isLike의 값이 일치하지않는 문제가 발생하여서 fix하였습니다.

# 본문
* commentLikeCommentIds의 where문에서 studentId를 비교하는 과정에서 해당 페이지 요청을 보낸 유저가 아닌 글쓴이와 정보를 비교하여 잘못된 정보를 가져오는 문제가 있어 수정하였습니다
* 또한, commentLikeCommentIds의 값이 CommentId가 아닌 CommentLikeId를 잘못 불러와 비교하는 과정에서 좋아요를 눌렀는지 인식이 되지 않는 문제가 생겨 수정하였습니다
* comments를 가져오는 과정의 where 조건문에 문제가 있어 수정하였습니다.
* writeComment를 하면 board에서 commentCount가 올라가지 않는 문제가 있어 fixed하였습니다.
* stageBoard 조회 api에서 commentCount 필드를 추가 반환하게 변경하였습니다.