### PR TITLE
[match] 매치 검색 DTO 필드 추가

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
@@ -56,7 +56,7 @@ class MatchServiceImpl(
         val allMatches = matchReader.readByStageId(stageId)
         val bettingBundle = bettingApi.bundle(allMatches.map{ it.id }, student.studentId)
         val betMatches = matchReader.readMy(bettingBundle.bettings.map { it.matchId })
-        return matchMapper.mapMy(bettingBundle, betMatches)
+        return matchMapper.mapMy(bettingBundle, betMatches, student.studentId)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -51,6 +51,8 @@ data class MatchSearchInfoDto(
     val gameName: String,
     val system: GameSystem,
     val turn: Int?,
+    val isNotice: Boolean,
+    val isPlayer: Boolean,
     val betting: MatchBettingInfoDto?,
     val result: MatchResultInfoDto?
 )


### PR DESCRIPTION
## 개요
매치 검색 API 스펙을 요구사항에 맞게 수정하였습니다.

## 본문
- `isPlayer`: 요청을 보낸 학생이 해당 매치(a team, b team)에 출전하는지
- `isNotice`: 해당 매치에 알림 설정을 했는지