### PR TITLE
[match] 매치 임시포인트 만료일 필드 추가

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
@@ -27,15 +27,19 @@ class MatchResult(
     @Column(name = "b_team_score", nullable = false)
     val bTeamScore: Int,
 
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    @Column(name = "team_point_expired_date", nullable = false)
+    val tempPointExpiredDate: LocalDateTime,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
     companion object {
 
-        fun of(match: Match, victoryTeam: Team, aTeamScore: Int, bTeamScore: Int)= MatchResult(
+        fun of(match: Match, victoryTeam: Team, aTeamScore: Int, bTeamScore: Int, tempPointExpiredDate: LocalDateTime)= MatchResult(
             match = match,
             victoryTeam = victoryTeam,
             aTeamScore = aTeamScore,
-            bTeamScore = bTeamScore
+            bTeamScore = bTeamScore,
+            tempPointExpiredDate = tempPointExpiredDate,
         )
 
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchMapper.kt
@@ -37,7 +37,6 @@ class MatchMapper(
 
         val matchInfoList = matches.map { matchEntity ->
             val bettingInfo = bundleDto.bettings.find { it.matchId == matchEntity.id }
-            val tempPointExpiredDate = matchEntity.endDate.plusMinutes(5)
             val resultInfo = bettingInfo?.result?.let {
                 MatchResultInfoDto(
                     victoryTeamId = matchEntity.matchResult!!.victoryTeam.id,
@@ -45,7 +44,7 @@ class MatchMapper(
                     bTeamScore = matchEntity.matchResult!!.bTeamScore,
                     isPredictionSuccess = it.isPredicted,
                     earnedPoint = it.earnedPoint,
-                    tempPointExpiredDate = tempPointExpiredDate,
+                    tempPointExpiredDate = matchEntity.matchResult!!.tempPointExpiredDate,
                 )
             } ?: matchEntity.matchResult?.let {
                 MatchResultInfoDto(
@@ -54,7 +53,7 @@ class MatchMapper(
                     bTeamScore = it.bTeamScore,
                     isPredictionSuccess = null,
                     earnedPoint = null,
-                    tempPointExpiredDate = tempPointExpiredDate,
+                    tempPointExpiredDate = matchEntity.matchResult!!.tempPointExpiredDate,
                 )
             }
 
@@ -117,8 +116,6 @@ class MatchMapper(
                 )
             }
 
-            val tempPointExpiredDate = match.endDate.plusMinutes(5)
-
             val isPlayer = match.aTeam?.participants?.any { it.studentId == studentId } == true ||
                     match.bTeam?.participants?.any { it.studentId == studentId } == true
             val isNotice = matchNotificationRepository.existsByMatchIdAndStudentId(match.id, studentId)
@@ -130,7 +127,7 @@ class MatchMapper(
                     bTeamScore = match.matchResult!!.bTeamScore,
                     isPredictionSuccess = it.isPredicted,
                     earnedPoint = it.earnedPoint,
-                    tempPointExpiredDate = tempPointExpiredDate
+                    tempPointExpiredDate = match.matchResult!!.tempPointExpiredDate,
                 )
             } ?: match.matchResult?.let {
                 MatchResultInfoDto(
@@ -139,7 +136,7 @@ class MatchMapper(
                     bTeamScore = it.bTeamScore,
                     isPredictionSuccess = null,
                     earnedPoint = null,
-                    tempPointExpiredDate = tempPointExpiredDate,
+                    tempPointExpiredDate = match.matchResult!!.tempPointExpiredDate,
                 )
             }
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -21,6 +21,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Component
 class MatchProcessor(
@@ -115,6 +116,7 @@ class MatchProcessor(
             victoryTeam = victoryTeam,
             aTeamScore = event.aTeamScore,
             bTeamScore = event.bTeamScore,
+            tempPointExpiredDate = LocalDateTime.now().plusMinutes(5)
         )
         matchResultRepository.save(matchResult)
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/persistence/TempPointRepository.kt
@@ -1,6 +1,5 @@
 package gogo.gogostage.domain.stage.participant.temppoint.persistence
 
-import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipant
 import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock

--- a/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
+++ b/src/main/kotlin/gogo/gogostage/global/kafka/consumer/dto/MatchBatchEvent.kt
@@ -9,7 +9,7 @@ data class MatchBatchEvent(
     val victoryTeamId: Long,
     @JsonProperty("ateamScore") val aTeamScore: Int,
     @JsonProperty("bteamScore") val bTeamScore: Int,
-    val students: List<StudentBettingDto>
+    val students: List<StudentBettingDto>,
 )
 
 data class StudentBettingDto(


### PR DESCRIPTION
## 개요
매치 도메인에 임시포인트 만료일 필드를 추가하였습니다.

## 본문
- 매치 검색시 임시포인트 만료일을 매치 종료시간 기준 +5분으로 내려주고 있는 문제가 있었습니다.
- 매치 정산시 매치 도메인의 임시포인트 만료일에 현재시간 +5분을 저장하고 매치 검색시 해당 필드를 내려줍니다.