### PR TITLE
[match] 매치 정산 취소 이벤트 핸들링시 임시포인트 반영 여부 검증식 수정

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -127,6 +127,13 @@ class MatchProcessor(
     fun cancelBatch(event: BatchCancelEvent) {
         val match = (matchRepository.findByIdOrNull(event.matchId)
             ?: throw StageException("매치를 찾을 수 없습니다. Match Id = ${event.matchId}.", HttpStatus.NOT_FOUND.value()))
+
+        val now = LocalDateTime.now()
+        val tempPointExpiredDate = match.matchResult!!.tempPointExpiredDate
+        if (now.isAfter(tempPointExpiredDate)) {
+            throw StageException("임시포인트가 이미 반영되었습니다.", HttpStatus.FORBIDDEN.value())
+        }
+
         match.batchRollback()
         matchRepository.save(match)
 

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -1,6 +1,5 @@
 package gogo.gogostage.domain.stage.participant.temppoint.application
 
-import gogo.gogostage.domain.match.result.persistence.MatchResultRepository
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
 import gogo.gogostage.domain.stage.participant.temppoint.persistence.TempPoint
@@ -18,7 +17,6 @@ class TempPointProcessor(
     private val matchRepository: MatchRepository,
     private val stageParticipantRepository: StageParticipantRepository,
     private val tempPointRepository: TempPointRepository,
-    private val matchResultRepository: MatchResultRepository,
 ) {
 
     fun addTempPoint(event: MatchBatchEvent) {

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/temppoint/application/TempPointProcessor.kt
@@ -51,11 +51,9 @@ class TempPointProcessor(
         val now = LocalDateTime.now()
         val tempPoints = tempPointRepository.findNotAppliedByBatchId(now, event.batchId)
 
-        if (tempPoints.isEmpty()) {
-            throw StageException("임시 포인트가 이미 반영되었습니다.", HttpStatus.NOT_FOUND.value())
+        if (tempPoints.isNotEmpty()) {
+            tempPointRepository.deleteAll(tempPoints)
         }
-
-        tempPointRepository.deleteAll(tempPoints)
     }
 
 }


### PR DESCRIPTION
## 개요
매치 정산 취소 이벤트(`match_batch_cancel`) 핸들링시 임시포인트 반영 여부 검증식을 수정했습니다.

## 본문
- 만약 정산 후 임시포인트를 받은 학생이 아무도 없는 경우 정산 취소시 임시포인트가 존재하지 않아서 이미 반영된 것으로 판단하는 이슈를 확인했습니다.
- #97 해당 작업에서 추가했던 임시포인트 반영 시간을 기준으로 검증하도록 수정하였습니다.