### PR TITLE
[team] 경기에 출전하는 팀 조회 response 추가 반환

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamMapper.kt
@@ -12,7 +12,8 @@ class TeamMapper {
         val gameTeamListDto = teams.map {GameTeamDto(
                 teamId = it.id,
                 teamName = it.name,
-                participantCount = it.participantCount
+                participantCount = it.participantCount,
+                winCount = it.winCount,
             )}
 
         return GameTeamResDto(

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
@@ -28,4 +28,5 @@ data class GameTeamDto(
     val teamId: Long,
     val teamName: String,
     val participantCount: Int,
+    val winCount: Int,
 )


### PR DESCRIPTION
# 개요
api specs에 winCount가 존재하지만 api에 누락되어 추가하였습니다

# 본문
* GameTeamDto에 winCount를 추가하여 mapper에서 it.winCount로 초기화 하도록 변경하였습니다