### PR TITLE
[stage] 커뮤니티 욕설 필터에 따른 글 조회 적용

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardReader
+import gogo.gogostage.domain.community.board.persistence.Board
 import gogo.gogostage.domain.community.comment.application.CommentReader
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
@@ -30,8 +31,8 @@ class CommunityReader(
         return communityRepository.searchCommunityBoardPage(stageId, size, category, sort, pageRequest)
     }
 
-    fun readBoardInfo(boardId: Long, student: StudentByIdStub): GetCommunityBoardInfoResDto =
-        communityRepository.getCommunityBoardInfo(boardId, student)
+    fun readBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto =
+        communityRepository.getCommunityBoardInfo(board, student)
 
     fun readBoardByBoardId(boardId: Long) =
         boardReader.read(boardId)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -26,13 +26,13 @@ class CommunityReader(
         communityRepository.findByStageIdAndCategory(stageId, gameCategory)
             ?: throw StageException("Community Not Found, stageId=$stageId gameCategory=$gameCategory", HttpStatus.NOT_FOUND.value())
 
-    fun readBoards(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
+    fun readBoards(isActiveProfanityFilter: Boolean, stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
         val pageRequest = PageRequest.of(page, size)
-        return communityRepository.searchCommunityBoardPage(stageId, size, category, sort, pageRequest)
+        return communityRepository.searchCommunityBoardPage(isActiveProfanityFilter, stageId, size, category, sort, pageRequest)
     }
 
-    fun readBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto =
-        communityRepository.getCommunityBoardInfo(board, student)
+    fun readBoardInfo(isActiveProfanityFilter: Boolean, board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto =
+        communityRepository.getCommunityBoardInfo(isActiveProfanityFilter, board, student)
 
     fun readBoardByBoardId(boardId: Long) =
         boardReader.read(boardId)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -1,9 +1,11 @@
 package gogo.gogostage.domain.community.root.application
 
 import gogo.gogostage.domain.community.board.application.BoardProcessor
+import gogo.gogostage.domain.community.board.application.BoardReader
 import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
+import gogo.gogostage.domain.stage.root.application.StageValidator
 import gogo.gogostage.global.util.UserContextUtil
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,12 +16,15 @@ class CommunityServiceImpl(
     private val boardProcessor: BoardProcessor,
     private val userUtil: UserContextUtil,
     private val communityProcessor: CommunityProcessor,
-    private val communityValidator: CommunityValidator
+    private val communityValidator: CommunityValidator,
+    private val stageValidator: StageValidator,
+    private val boardReader: BoardReader
 ): CommunityService {
 
     @Transactional
     override fun writeCommunityBoard(stageId: Long, writeCommunityBoardDto: WriteCommunityBoardDto) {
         val student = userUtil.getCurrentStudent()
+        stageValidator.validStage(student, stageId)
         val community = communityReader.readByStageIdAndGameCategory(stageId, writeCommunityBoardDto.gameCategory)
         boardProcessor.saveCommunityBoard(community, student.studentId, writeCommunityBoardDto)
 
@@ -28,6 +33,8 @@ class CommunityServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getStageBoard(stageId: Long, page: Int, size: Int, category: GameCategory?, sort: SortType): GetCommunityBoardResDto {
+        val student = userUtil.getCurrentStudent()
+        stageValidator.validStage(student, stageId)
         communityValidator.validPageAndSize(page, size)
         return communityReader.readBoards(stageId, page, size, category, sort)
     }
@@ -35,13 +42,16 @@ class CommunityServiceImpl(
     @Transactional(readOnly = true)
     override fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto {
         val student = userUtil.getCurrentStudent()
-        return communityReader.readBoardInfo(boardId, student)
+        val board = boardReader.read(boardId)
+        stageValidator.validStage(student, board.community.stage.id)
+        return communityReader.readBoardInfo(board, student)
     }
 
     @Transactional
     override fun likeStageBoard(boardId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
+        stageValidator.validStage(student, board.community.stage.id)
         return communityProcessor.likeBoard(student.studentId, board)
     }
 
@@ -49,6 +59,7 @@ class CommunityServiceImpl(
     override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
+        stageValidator.validStage(student, board.community.stage.id)
         // 욕설 필터링 필요
         return communityProcessor.saveBoardComment(student, writeBoardCommentDto, board)
     }
@@ -57,6 +68,7 @@ class CommunityServiceImpl(
     override fun likeBoardComment(commentId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
         val comment = communityReader.readCommentByCommentId(commentId)
+        stageValidator.validStage(student, comment.board.community.stage.id)
         return communityProcessor.likeBoardComment(student, comment)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -36,7 +36,8 @@ class CommunityServiceImpl(
         val student = userUtil.getCurrentStudent()
         stageValidator.validStage(student, stageId)
         communityValidator.validPageAndSize(page, size)
-        return communityReader.readBoards(stageId, page, size, category, sort)
+        val isActiveProfanityFilter = student.isActiveProfanityFilter
+        return communityReader.readBoards(isActiveProfanityFilter, stageId, page, size, category, sort)
     }
 
     @Transactional(readOnly = true)
@@ -44,7 +45,8 @@ class CommunityServiceImpl(
         val student = userUtil.getCurrentStudent()
         val board = boardReader.read(boardId)
         stageValidator.validStage(student, board.community.stage.id)
-        return communityReader.readBoardInfo(board, student)
+        val isActiveProfanityFilter = student.isActiveProfanityFilter
+        return communityReader.readBoardInfo(isActiveProfanityFilter, board, student)
     }
 
     @Transactional

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -8,6 +8,6 @@ import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.data.domain.Pageable
 
 interface CommunityCustomRepository {
-    fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
-    fun getCommunityBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto
+    fun searchCommunityBoardPage(isActiveProfanityFilter: Boolean, stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
+    fun getCommunityBoardInfo(isActiveProfanityFilter: Boolean, board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepository.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.community.root.persistence
 
+import gogo.gogostage.domain.community.board.persistence.Board
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardInfoResDto
 import gogo.gogostage.domain.community.root.application.dto.GetCommunityBoardResDto
 import gogo.gogostage.domain.game.persistence.GameCategory
@@ -8,5 +9,5 @@ import org.springframework.data.domain.Pageable
 
 interface CommunityCustomRepository {
     fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto
-    fun getCommunityBoardInfo(boardId: Long, student: StudentByIdStub): GetCommunityBoardInfoResDto
+    fun getCommunityBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -1,11 +1,9 @@
 package gogo.gogostage.domain.community.root.persistence
 
 import com.querydsl.core.BooleanBuilder
-import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import gogo.gogostage.domain.community.board.persistence.Board
 import gogo.gogostage.domain.community.board.persistence.BoardRepository
-import gogo.gogostage.domain.community.board.persistence.QBoard
 import gogo.gogostage.domain.community.board.persistence.QBoard.board
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
 import gogo.gogostage.domain.community.comment.persistence.QComment.comment
@@ -13,12 +11,9 @@ import gogo.gogostage.domain.community.commentlike.persistence.QCommentLike.comm
 import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.QCommunity.community
 import gogo.gogostage.domain.game.persistence.GameCategory
-import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.api.StudentApi
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.data.domain.Pageable
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.http.HttpStatus
 
 import org.springframework.stereotype.Repository
 
@@ -26,7 +21,6 @@ import org.springframework.stereotype.Repository
 class CommunityCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
     private val studentApi: StudentApi,
-    private val boardRepository: BoardRepository,
     private val boardLikeRepository: BoardLikeRepository
 ): CommunityCustomRepository {
 
@@ -104,10 +98,7 @@ class CommunityCustomRepositoryImpl(
         return GetCommunityBoardResDto(infoDto, boardDtoList)
     }
 
-    override fun getCommunityBoardInfo(boardId: Long, student: StudentByIdStub): GetCommunityBoardInfoResDto {
-        val board = boardRepository.findByIdOrNull(boardId)
-            ?: throw StageException("Board Not Found, boardId = $boardId", HttpStatus.NOT_FOUND.value())
-
+    override fun getCommunityBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto {
         val stageDto = StageDto(board.community.stage.name, board.community.category)
 
         val boardAuthorList = listOf(board.studentId)
@@ -120,7 +111,7 @@ class CommunityCustomRepositoryImpl(
 
         val predicate = BooleanBuilder()
 
-        predicate.and(comment.board.id.eq(boardId))
+        predicate.and(comment.board.id.eq(board.id))
 
         val comments = queryFactory.selectFrom(comment)
             .where(predicate)
@@ -130,7 +121,7 @@ class CommunityCustomRepositoryImpl(
 
         val commentLikeCommentIds = queryFactory.select(commentLike.comment.id)
             .from(commentLike)
-            .where(commentLike.comment.board.id.eq(boardId).and(
+            .where(commentLike.comment.board.id.eq(board.id).and(
                 commentLike.studentId.eq(student.studentId)
             ))
             .fetch()

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -24,13 +24,19 @@ class CommunityCustomRepositoryImpl(
     private val boardLikeRepository: BoardLikeRepository
 ): CommunityCustomRepository {
 
-    override fun searchCommunityBoardPage(stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto {
+    override fun searchCommunityBoardPage(isActiveProfanityFilter: Boolean, stageId: Long, size: Int, category: GameCategory?, sort: SortType, pageable: Pageable): GetCommunityBoardResDto {
         val predicate = BooleanBuilder()
 
         predicate.and(community.stage.id.eq(stageId))
 
         category?.let {
             predicate.and(community.category.eq(it))
+        }
+
+        if(isActiveProfanityFilter) {
+            predicate.and(board.isFiltered.eq(true))
+        } else {
+            predicate.and(board.isFiltered.eq(false))
         }
 
         val boards = queryFactory
@@ -98,7 +104,7 @@ class CommunityCustomRepositoryImpl(
         return GetCommunityBoardResDto(infoDto, boardDtoList)
     }
 
-    override fun getCommunityBoardInfo(board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto {
+    override fun getCommunityBoardInfo(isActiveProfanityFilter: Boolean, board: Board, student: StudentByIdStub): GetCommunityBoardInfoResDto {
         val stageDto = StageDto(board.community.stage.name, board.community.category)
 
         val boardAuthorList = listOf(board.studentId)
@@ -110,6 +116,12 @@ class CommunityCustomRepositoryImpl(
         val isAuthorBoardLike = boardLikeRepository.existsByStudentIdAndBoardId(boardAuthorDto.studentId, board.id)
 
         val predicate = BooleanBuilder()
+
+        if(isAuthorBoardLike) {
+            predicate.and(comment.isFiltered.eq(true))
+        } else {
+            predicate.and(comment.isFiltered.eq(false))
+        }
 
         predicate.and(comment.board.id.eq(board.id))
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import gogo.gogostage.domain.community.board.persistence.Board
 import gogo.gogostage.domain.community.board.persistence.BoardRepository
+import gogo.gogostage.domain.community.board.persistence.QBoard
 import gogo.gogostage.domain.community.board.persistence.QBoard.board
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
 import gogo.gogostage.domain.community.comment.persistence.QComment.comment
@@ -33,11 +34,7 @@ class CommunityCustomRepositoryImpl(
             predicate.and(community.category.eq(it))
         }
 
-        if(isActiveProfanityFilter) {
-            predicate.and(board.isFiltered.eq(true))
-        } else {
-            predicate.and(board.isFiltered.eq(false))
-        }
+        predicate.and(board.isFiltered.eq(isActiveProfanityFilter))
 
         val boards = queryFactory
             .selectFrom(board)
@@ -117,11 +114,7 @@ class CommunityCustomRepositoryImpl(
 
         val predicate = BooleanBuilder()
 
-        if(isAuthorBoardLike) {
-            predicate.and(comment.isFiltered.eq(true))
-        } else {
-            predicate.and(comment.isFiltered.eq(false))
-        }
+        predicate.and(comment.isFiltered.eq(isActiveProfanityFilter))
 
         predicate.and(comment.board.id.eq(board.id))
 


### PR DESCRIPTION
# 개요
커뮤니티 욕설 필터에 따른 글 조회 적용과 해당 학생이 해당 스테이지에 참여중인지 검증하는 로직을 추가하였습니다

# 본문
* community관련 API에 validStage를 추가하여 해당 유저가 스테이지에 참여중인지 검증하는 로직을 추가하였습니다.
* 커뮤니티 욕설 필터관련 조회 로직에 만약에 필터를 켰다면 욕설필터에 걸리지 않은 글만 반환합니다. 반면에 필터가 꺼져있다면 모든 글을 반환하게 됩니다.