### PR TITLE
[community] 커뮤니티 게시글, 댓글 좋아요 동시성 처리

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardReader.kt
@@ -15,4 +15,8 @@ class BoardReader(
         boardRepository.findByIdOrNull(boardId)
             ?: throw StageException("Board Not Found, boardId=$boardId", HttpStatus.NOT_FOUND.value())
 
+    fun readForWrite(boardId: Long) =
+        boardRepository.findByIdForWrite(boardId)
+            ?: throw StageException("Board Not Found, boardId=$boardId", HttpStatus.NOT_FOUND.value())
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/BoardRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/BoardRepository.kt
@@ -1,6 +1,14 @@
 package gogo.gogostage.domain.community.board.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface BoardRepository: JpaRepository<Board, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Board b WHERE b.id = :boardId")
+    fun findByIdForWrite(boardId: Long): Board?
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/application/CommentReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/application/CommentReader.kt
@@ -15,4 +15,8 @@ class CommentReader(
         commentRepository.findByIdOrNull(commentId)
             ?: throw StageException("Comment Not Found, commentId=$commentId", HttpStatus.NOT_FOUND.value())
 
+    fun readForWrite(commentId: Long) =
+        commentRepository.findByIdOrNull(commentId)
+            ?: throw StageException("Comment Not Found, commentId=$commentId", HttpStatus.NOT_FOUND.value())
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/CommentRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/persistence/CommentRepository.kt
@@ -1,7 +1,15 @@
 package gogo.gogostage.domain.community.comment.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface CommentRepository: JpaRepository<Comment, Long> {
     fun findByBoardIdAndStudentId(boardId: Long, studentId: Long): Comment?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Comment c WHERE c.id = :commentId")
+    fun findByIdForWrite(commentId: Long): Comment?
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -25,7 +25,6 @@ class CommunityProcessor(
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeResDto {
-        // 동시성 문제
         val isExistBoardLike = boardLikeRepository.existsByStudentIdAndBoardId(studentId, board.id)
 
         if (isExistBoardLike) {

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -42,4 +42,7 @@ class CommunityReader(
     fun readCommentByCommentId(commentId: Long) =
         commentReader.read(commentId)
 
+    fun readCommentByCommentIdForWrite(commentId: Long) =
+        commentReader.readForWrite(commentId)
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityReader.kt
@@ -36,6 +36,9 @@ class CommunityReader(
     fun readBoardByBoardId(boardId: Long) =
         boardReader.read(boardId)
 
+    fun readBoardByBoardIdForWrite(boardId: Long) =
+        boardReader.readForWrite(boardId)
+
     fun readCommentByCommentId(commentId: Long) =
         commentReader.read(commentId)
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -41,7 +41,7 @@ class CommunityServiceImpl(
     @Transactional
     override fun likeStageBoard(boardId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
-        val board = communityReader.readBoardByBoardId(boardId)
+        val board = communityReader.readBoardByBoardIdForWrite(boardId)
         return communityProcessor.likeBoard(student.studentId, board)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -56,7 +56,7 @@ class CommunityServiceImpl(
     @Transactional
     override fun likeBoardComment(commentId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
-        val comment = communityReader.readCommentByCommentId(commentId)
+        val comment = communityReader.readCommentByCommentIdForWrite(commentId)
         return communityProcessor.likeBoardComment(student, comment)
     }
 


### PR DESCRIPTION
## 개요
커뮤니티 게시글, 댓글 좋아요 동시성 문제를 핸들링 하였습니다.

## 본문
- 게시글 좋아요, 댓글 좋아요 서비스에서 pk로 조회하는 쿼리에서 row lock을 걸어 동시성을 처리하였습니다.