### PR TITLE
[team] 팀 조회 API 캐시 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ repositories {
 extra["springCloudVersion"] = "2024.0.0-RC1"
 
 dependencies {
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.cloud:spring-cloud-starter-config")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamServiceImpl.kt
@@ -4,7 +4,10 @@ import gogo.gogostage.domain.game.application.GameReader
 import gogo.gogostage.domain.stage.root.application.StageValidator
 import gogo.gogostage.domain.team.root.application.dto.GameTeamResDto
 import gogo.gogostage.domain.team.root.application.dto.TeamApplyDto
+import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.util.UserContextUtil
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,6 +23,7 @@ class TeamServiceImpl(
 ) : TeamService {
 
     @Transactional
+    @CacheEvict(value = [CacheConstant.TEMP_TEAM_CACHE_VALUE], key = "#gameId", cacheManager = "cacheManager")
     override fun apply(gameId: Long, dto: TeamApplyDto) {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
@@ -29,6 +33,7 @@ class TeamServiceImpl(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.TEAM_CACHE_VALUE], key = "#gameId", cacheManager = "cacheManager")
     override fun getGameTeam(gameId: Long): GameTeamResDto {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
@@ -38,6 +43,7 @@ class TeamServiceImpl(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.TEMP_TEAM_CACHE_VALUE], key = "#gameId", cacheManager = "cacheManager")
     override fun getGameTempTeam(gameId: Long): GameTeamResDto {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
@@ -20,13 +20,13 @@ data class TeamParticipantDto(
 )
 
 data class GameTeamResDto(
-    val count: Int,
-    val team: List<GameTeamDto>
+    val count: Int = 0,
+    val team: List<GameTeamDto> = emptyList(),
 )
 
 data class GameTeamDto(
-    val teamId: Long,
-    val teamName: String,
-    val participantCount: Int,
-    val winCount: Int,
+    val teamId: Long = 0L,
+    val teamName: String = "",
+    val participantCount: Int = 0,
+    val winCount: Int = 0,
 )

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -1,0 +1,6 @@
+package gogo.gogostage.global.cache
+
+object CacheConstant {
+    const val TEAM_CACHE_VALUE = "team"
+    const val TEMP_TEAM_CACHE_VALUE = "temp_team"
+}

--- a/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
@@ -1,0 +1,70 @@
+package gogo.gogostage.global.config
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.CacheKeyPrefix
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    private val host: String,
+    @Value("\${spring.data.redis.port}")
+    private val port: Int
+) {
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        val redisConfig = RedisStandaloneConfiguration(host, port)
+        val clientConfig = LettuceClientConfiguration.builder()
+            .commandTimeout(Duration.ofSeconds(1))
+            .shutdownTimeout(Duration.ZERO)
+            .build()
+
+        return LettuceConnectionFactory(redisConfig, clientConfig)
+    }
+
+      // 역작렬화 문제
+//    @Bean
+//    fun objectMapper(): ObjectMapper {
+//        return ObjectMapper().apply {
+//            registerModule(KotlinModule.Builder().build())
+//            registerModule(JavaTimeModule())
+//            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+//        }
+//    }
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val serializer = GenericJackson2JsonRedisSerializer()
+        val configuration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .entryTtl(Duration.ofHours(1))
+            .disableCachingNullValues()
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory())
+            .cacheDefaults(configuration)
+            .build()
+    }
+}


### PR DESCRIPTION
## 개요
팀 관련 조회 API에 캐시를 적용하였습니다.

## 본문
- 임시 팀 리스트 조회, 출전 팀 리스트 조회, 팀 상세 조회 API에 캐시를 적용하였습니다.
- 캐시 저장소는 Redis 저장소를 사용하였습니다. (TTL 1시간)
- 만약 팀 추가시 임시 팀 리스트 캐시를 삭제하도록 이빅트를 설정해두었습니다.

## 유의사항
- 기본 생성자 문제로 캐시 역직렬화 문제가 발생하였습니다. 우선 DTO 객체에 기본 값을 할당하여 해결해두었습니다. 추후 ObjectMapper 빈을 설정하여 해결할 예정입니다.