### PR TITLE
[team] 팀 신청시 경기 팀 수 추가

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/persistence/Game.kt
@@ -38,7 +38,7 @@ class Game(
     var firstPlaceTeam: Team? = null,
 
     @Column(name = "team_count", nullable = false)
-    val teamCount: Int = 0, // 팀 신청시 ++
+    var teamCount: Int = 0,
 
     @Column(name = "league_count", nullable = true)
     var leagueCount: Int? = null,
@@ -78,6 +78,10 @@ class Game(
     fun endRollBack() {
         this.isEnd = false
         this.firstPlaceTeam = null
+    }
+
+    fun addTeam() {
+        this.teamCount++
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResult.kt
@@ -17,7 +17,7 @@ class MatchResult(
     @JoinColumn(name = "match_id", nullable = false)
     val match: Match,
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "victory_team_id", nullable = false)
     val victoryTeam: Team,
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/result/persistence/MatchResultRepository.kt
@@ -1,7 +1,11 @@
 package gogo.gogostage.domain.match.result.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface MatchResultRepository: JpaRepository<MatchResult, Long> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM MatchResult mr WHERE mr.match.id = :matchId")
     fun deleteByMatchId(matchId: Long)
 }

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamProcessor.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.team.root.application
 
 import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.game.persistence.GameRepository
 import gogo.gogostage.domain.team.participant.persistence.TeamParticipant
 import gogo.gogostage.domain.team.participant.persistence.TeamParticipantRepository
 import gogo.gogostage.domain.team.root.application.dto.TeamApplyDto
@@ -11,12 +12,16 @@ import org.springframework.stereotype.Component
 @Component
 class TeamProcessor(
     private val teamRepository: TeamRepository,
-    private val teamParticipantRepository: TeamParticipantRepository
+    private val teamParticipantRepository: TeamParticipantRepository,
+    private val gameRepository: GameRepository
 ) {
 
     fun apply(game: Game, dto: TeamApplyDto) {
         val team = Team.of(game, dto.teamName, dto.participants.size)
         teamRepository.save(team)
+
+        game.addTeam()
+        gameRepository.save(game)
 
         val participants = dto.participants.map {
             TeamParticipant.of(team, it.studentId, it.positionX, it.positionY)


### PR DESCRIPTION
## 개요
팀 신청시 팀의 경기의 teamCount를 추가하는 로직을 작성하였습니다.

## 추가사항
- Team 엔티티와 TeamResult 엔티티의 관계를 N:1 관계로 수정하였습니다.
- batch cancel 이벤트 핸들링시 match result 삭제 쿼리에 `@Modifying` 어노테이션을 추가하였습니다.