### PR TITLE
[community] 게시글 content 길이 변경

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
@@ -22,7 +22,7 @@ class Board(
     @Column(name = "title", nullable = false)
     val title: String,
 
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", nullable = false, length = 1000)
     val content: String,
 
     @Column(name = "comment_count", nullable = false)


### PR DESCRIPTION
# 개요
디자인과 달리 content의 길이가 255로 제한되어 1000으로 fix하였습니다.

# 본문
content의 컬럼 조건을 length를 1000으로 변경하였습니다
