### PR TITLE
[community] 댓글 좋아요 lock 메서드 사용하지 않는 부분 수정

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/comment/application/CommentReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/comment/application/CommentReader.kt
@@ -16,7 +16,7 @@ class CommentReader(
             ?: throw StageException("Comment Not Found, commentId=$commentId", HttpStatus.NOT_FOUND.value())
 
     fun readForWrite(commentId: Long) =
-        commentRepository.findByIdOrNull(commentId)
+        commentRepository.findByIdForWrite(commentId)
             ?: throw StageException("Comment Not Found, commentId=$commentId", HttpStatus.NOT_FOUND.value())
 
 }


### PR DESCRIPTION
## 개요
댓글 좋아요 서비스에서 댓글 조회시 row lock을 잡는 메서드에서 lock을 잡는 repository method를 사용하지 않는 부분을 수정하였습니다.