### PR TITLE
[batch] 정산 취소시 승리팀 win count rollback

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -134,6 +134,10 @@ class MatchProcessor(
             throw StageException("임시포인트가 이미 반영되었습니다.", HttpStatus.FORBIDDEN.value())
         }
 
+        val victoryTeam = match.matchResult!!.victoryTeam
+        victoryTeam.rollbackWinCount()
+        teamRepository.save(victoryTeam)
+
         match.batchRollback()
         matchRepository.save(match)
 

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/persistence/Team.kt
@@ -54,4 +54,8 @@ class Team(
         this.winCount++
     }
 
+    fun rollbackWinCount() {
+        this.winCount--
+    }
+
 }


### PR DESCRIPTION
## 개요
정산 취소시 승리팀 win count를 rollback하도록 하였습니다.

## 본문
- 정산 취소시 승리팀의 winCount 필드의 차감이 누락되어 추가하였습니다.