### PR TITLE
[match] 매치 알림 토클 동시성 문제, 연관관계 문제 해결

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/notification/application/MatchNotificationReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/notification/application/MatchNotificationReader.kt
@@ -10,8 +10,8 @@ class MatchNotificationReader(
     private val matchNotificationRepository: MatchNotificationRepository
 ) {
 
-    fun readByMatchIdAndStudentId(matchId: Long, studentId: Long) =
-        matchNotificationRepository.findByMatchIdAndStudentId(matchId, studentId)
+    fun readByMatchIdAndStudentIdForWrite(matchId: Long, studentId: Long) =
+        matchNotificationRepository.findByMatchIdAndStudentIdForWrite(matchId, studentId)
             ?: throw StageException("MatchNotification Not Found, matchId=$matchId, studentId=$studentId", HttpStatus.NOT_FOUND.value())
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotification.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotification.kt
@@ -11,7 +11,7 @@ class MatchNotification(
     @Column(name = "id", nullable = false)
     val id: Long = 0,
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "match_id", nullable = false)
     val match: Match,
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotificationRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotificationRepository.kt
@@ -1,8 +1,10 @@
 package gogo.gogostage.domain.match.notification.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface MatchNotificationRepository: JpaRepository<MatchNotification, Long> {
-    fun findByMatchIdAndStudentId(matchId: Long, studentId: Long): MatchNotification?
+    @Query("SELECT mn FROM MatchNotification mn WHERE mn.match.id = :matchId AND mn.studentId = :studentId")
+    fun findByMatchIdAndStudentIdForWrite(matchId: Long, studentId: Long): MatchNotification?
     fun existsByMatchIdAndStudentId(matchId: Long, studentId: Long): Boolean
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotificationRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/notification/persistence/MatchNotificationRepository.kt
@@ -1,9 +1,12 @@
 package gogo.gogostage.domain.match.notification.persistence
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 
 interface MatchNotificationRepository: JpaRepository<MatchNotification, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT mn FROM MatchNotification mn WHERE mn.match.id = :matchId AND mn.studentId = :studentId")
     fun findByMatchIdAndStudentIdForWrite(matchId: Long, studentId: Long): MatchNotification?
     fun existsByMatchIdAndStudentId(matchId: Long, studentId: Long): Boolean

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -5,6 +5,7 @@ import gogo.gogostage.domain.match.notification.persistence.MatchNotificationRep
 import gogo.gogostage.domain.match.root.application.dto.MatchToggleDto
 import gogo.gogostage.domain.game.persistence.GameRepository
 import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.match.notification.application.MatchNotificationReader
 import gogo.gogostage.domain.match.result.persistence.MatchResult
 import gogo.gogostage.domain.match.result.persistence.MatchResultRepository
 import gogo.gogostage.domain.match.root.persistence.Match
@@ -30,13 +31,13 @@ class MatchProcessor(
     private val teamRepository: TeamRepository,
     private val matchResultRepository: MatchResultRepository,
     private val tempPointProcessor: TempPointProcessor,
-    private val gameRepository: GameRepository
+    private val gameRepository: GameRepository,
+    private val matchNotificationReader: MatchNotificationReader
 ) {
 
     fun toggleMatchNotification(match: Match, student: StudentByIdStub): MatchToggleDto {
         if (matchNotificationRepository.existsByMatchIdAndStudentId(match.id, student.studentId)) {
-            val matchNotification = matchNotificationRepository.findByMatchIdAndStudentId(match.id, student.studentId)
-                ?: throw StageException("MatchNotification Not Found, matchId=${match.id}, studentId=${student.studentId}", HttpStatus.NOT_FOUND.value())
+            val matchNotification = matchNotificationReader.readByMatchIdAndStudentIdForWrite(match.id, student.studentId)
 
             matchNotificationRepository.delete(matchNotification)
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
@@ -1,19 +1,15 @@
 package gogo.gogostage.domain.match.root.application
 
-import gogo.gogostage.domain.match.notification.application.MatchNotificationReader
 import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.global.error.StageException
-import gogo.gogostage.global.internal.betting.api.BettingApi
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 
 @Component
 class MatchReader(
-    private val matchNotificationReader: MatchNotificationReader,
     private val matchRepository: MatchRepository,
-    private val bettingApi: BettingApi
 ) {
 
     fun read(matchId: Long): Match =
@@ -30,9 +26,4 @@ class MatchReader(
     fun info(matchId: Long): Match =
         matchRepository.info(matchId)
             ?: throw StageException("Match not found, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
-
-    fun readMatchNotificationByMatchIdAndStudentId(matchId: Long, studentId: Long) =
-        matchNotificationReader.readByMatchIdAndStudentId(matchId, studentId)
-
-
 }


### PR DESCRIPTION
# 개요
매치 알림을 토클하면 생기는 엔티티에서 연관관계가 잘못 설정 되어 있어 해결하였고 동시성 문제가 일어나 동시성 제어 하였습니다.

# 본문
* tbl_match_notification 엔티티에서 matchId가 OneToOne으로 설정되어 UNIQUE 제약 조건이 걸려 생기던 오류를 ManyToOne으로 변경하여 해결하였습니다.
* 알림 토클을 하면서 동시성 문제가 발생하여 row lock을 걸어 제어하였습니다