### PR TITLE
[game] 경기 대진표 조회 API

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameMapper.kt
@@ -1,8 +1,9 @@
 package gogo.gogostage.domain.game.application
 
-import gogo.gogostage.domain.game.application.dto.QueryGameDto
-import gogo.gogostage.domain.game.application.dto.QueryGameInfoDto
+import gogo.gogostage.domain.game.application.dto.*
 import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.match.root.persistence.Match
+import gogo.gogostage.domain.match.root.persistence.Round
 import org.springframework.stereotype.Component
 
 @Component
@@ -22,5 +23,33 @@ class GameMapper {
             )
         }
     )
+
+    fun mapFormat(matches: List<Match>): QueryGameFormatDto {
+        val rounds = listOf(Round.ROUND_OF_32, Round.ROUND_OF_32, Round.QUARTER_FINALS, Round.SEMI_FINALS, Round.FINALS)
+        val format = rounds.map { makeFormatMatch(matches, it) }
+        return QueryGameFormatDto(format)
+    }
+
+    fun makeFormatMatch(matches: List<Match>, round: Round): QueryGameFormatInfoDto {
+        val formatMatches = matches
+            .filter { it.round == round }
+            .map {
+                QueryGameFormatMatchInfoDto(
+                    matchId = it.id,
+                    turn = it.turn!!,
+                    aTeamId = it.aTeam!!.id,
+                    aTeamName = it.aTeam!!.name,
+                    bTeamId = it.bTeam!!.id,
+                    bTeamName = it.bTeam!!.name,
+                    isEnd = it.isEnd,
+                    winTeamId = it.matchResult?.victoryTeam?.id
+                )
+            }
+
+        return QueryGameFormatInfoDto(
+            round = round,
+            match = formatMatches,
+        )
+    }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameMapper.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameMapper.kt
@@ -26,11 +26,11 @@ class GameMapper {
 
     fun mapFormat(matches: List<Match>): QueryGameFormatDto {
         val rounds = listOf(Round.ROUND_OF_32, Round.ROUND_OF_32, Round.QUARTER_FINALS, Round.SEMI_FINALS, Round.FINALS)
-        val format = rounds.map { makeFormatMatch(matches, it) }
+        val format = rounds.mapNotNull { makeFormatMatch(matches, it) }
         return QueryGameFormatDto(format)
     }
 
-    fun makeFormatMatch(matches: List<Match>, round: Round): QueryGameFormatInfoDto {
+    fun makeFormatMatch(matches: List<Match>, round: Round): QueryGameFormatInfoDto? {
         val formatMatches = matches
             .filter { it.round == round }
             .map {
@@ -45,6 +45,8 @@ class GameMapper {
                     winTeamId = it.matchResult?.victoryTeam?.id
                 )
             }
+
+        if (formatMatches.isEmpty()) return null
 
         return QueryGameFormatInfoDto(
             round = round,

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameService.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameService.kt
@@ -1,7 +1,9 @@
 package gogo.gogostage.domain.game.application
 
 import gogo.gogostage.domain.game.application.dto.QueryGameDto
+import gogo.gogostage.domain.game.application.dto.QueryGameFormatDto
 
 interface GameService {
     fun queryAll(stageId: Long): QueryGameDto
+    fun queryFormat(gameId: Long): QueryGameFormatDto
 }

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
@@ -1,6 +1,8 @@
 package gogo.gogostage.domain.game.application
 
 import gogo.gogostage.domain.game.application.dto.QueryGameDto
+import gogo.gogostage.domain.game.application.dto.QueryGameFormatDto
+import gogo.gogostage.domain.match.root.application.MatchReader
 import gogo.gogostage.domain.stage.root.application.StageValidator
 import gogo.gogostage.global.util.UserContextUtil
 import org.springframework.stereotype.Service
@@ -11,7 +13,9 @@ class GameServiceImpl(
     private val gameReader: GameReader,
     private val userUtil: UserContextUtil,
     private val stageValidator: StageValidator,
-    private val gameMapper: GameMapper
+    private val gameMapper: GameMapper,
+    private val gameValidator: GameValidator,
+    private val matchReader: MatchReader
 ) : GameService {
 
     @Transactional(readOnly = true)
@@ -20,6 +24,16 @@ class GameServiceImpl(
         stageValidator.validStage(student, stageId)
         val games = gameReader.readByStageId(stageId)
         return gameMapper.mapAll(games)
+    }
+
+    @Transactional(readOnly = true)
+    override fun queryFormat(gameId: Long): QueryGameFormatDto {
+        val student = userUtil.getCurrentStudent()
+        val game = gameReader.read(gameId)
+        stageValidator.validStage(student, game.stage.id)
+        gameValidator.validFormat(game)
+        val matches = matchReader.readAllByGameId(gameId)
+        return gameMapper.mapFormat(matches)
     }
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
@@ -28,9 +28,9 @@ class GameServiceImpl(
 
     @Transactional(readOnly = true)
     override fun queryFormat(gameId: Long): QueryGameFormatDto {
-        val student = userUtil.getCurrentStudent()
+//        val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
-        stageValidator.validStage(student, game.stage.id)
+//        stageValidator.validStage(student, game.stage.id)
         gameValidator.validFormat(game)
         val matches = matchReader.readAllByGameId(gameId)
         return gameMapper.mapFormat(matches)

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
@@ -28,9 +28,9 @@ class GameServiceImpl(
 
     @Transactional(readOnly = true)
     override fun queryFormat(gameId: Long): QueryGameFormatDto {
-//        val student = userUtil.getCurrentStudent()
+        val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)
-//        stageValidator.validStage(student, game.stage.id)
+        stageValidator.validStage(student, game.stage.id)
         gameValidator.validFormat(game)
         val matches = matchReader.readAllByGameId(gameId)
         return gameMapper.mapFormat(matches)

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameValidator.kt
@@ -1,0 +1,18 @@
+package gogo.gogostage.domain.game.application
+
+import gogo.gogostage.domain.game.persistence.Game
+import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.global.error.StageException
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+
+@Component
+class GameValidator {
+
+    fun validFormat(game: Game) {
+        if (game.system != GameSystem.TOURNAMENT) {
+            throw StageException("해당 경기의 시스템이 토너먼트가 아닙니다.", HttpStatus.BAD_REQUEST.value())
+        }
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -2,6 +2,8 @@ package gogo.gogostage.domain.game.application.dto
 
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.game.persistence.GameSystem
+import gogo.gogostage.domain.match.root.application.dto.MatchBettingInfoDto
+import gogo.gogostage.domain.match.root.persistence.Round
 
 data class QueryGameDto(
     val count: Int,
@@ -16,4 +18,24 @@ data class QueryGameInfoDto(
     val teamMaxCapacity: Int,
     val category: GameCategory,
     val system: GameSystem,
+)
+
+data class QueryGameFormatDto(
+    val format: List<QueryGameFormatInfoDto>
+)
+
+data class QueryGameFormatInfoDto(
+    val round: Round,
+    val match: List<QueryGameFormatMatchInfoDto>,
+)
+
+data class QueryGameFormatMatchInfoDto(
+    val matchId: Long,
+    val turn: Int,
+    val aTeamId: Long,
+    val aTeamName: String,
+    val bTeamId: Long,
+    val bTeamName: String,
+    val isEnd: Boolean,
+    val winTeamId: Long?
 )

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -2,7 +2,6 @@ package gogo.gogostage.domain.game.application.dto
 
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.game.persistence.GameSystem
-import gogo.gogostage.domain.match.root.application.dto.MatchBettingInfoDto
 import gogo.gogostage.domain.match.root.persistence.Round
 
 data class QueryGameDto(

--- a/src/main/kotlin/gogo/gogostage/domain/game/presentation/GameController.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/presentation/GameController.kt
@@ -2,6 +2,7 @@ package gogo.gogostage.domain.game.presentation
 
 import gogo.gogostage.domain.game.application.GameService
 import gogo.gogostage.domain.game.application.dto.QueryGameDto
+import gogo.gogostage.domain.game.application.dto.QueryGameFormatDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,6 +20,14 @@ class GameController(
         @PathVariable("stage_id") stageId: Long
     ): ResponseEntity<QueryGameDto> {
         val response = gameService.queryAll(stageId)
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/game/format/{game_id}")
+    fun format(
+        @PathVariable("game_id") gameId: Long
+    ): ResponseEntity<QueryGameFormatDto> {
+        val response = gameService.queryFormat(gameId)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchReader.kt
@@ -26,4 +26,7 @@ class MatchReader(
     fun info(matchId: Long): Match =
         matchRepository.info(matchId)
             ?: throw StageException("Match not found, Match Id: $matchId", HttpStatus.NOT_FOUND.value())
+
+    fun readAllByGameId(gameId: Long): List<Match> = matchRepository.findAllByGameId(gameId)
+
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -24,5 +24,12 @@ interface MatchRepository: JpaRepository<Match, Long>, MatchCustomRepository {
        """)
     fun findMy(matchIds: List<Long>): List<Match>
 
+    @Query("""
+        SELECT m 
+        FROM Match m 
+        LEFT JOIN FETCH m.matchResult mr
+        LEFT JOIN FETCH m.game g
+        WHERE g.id = :gameId
+    """)
     fun findAllByGameId(gameId: Long): List<Match>
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/persistence/MatchRepository.kt
@@ -23,4 +23,6 @@ interface MatchRepository: JpaRepository<Match, Long>, MatchCustomRepository {
             WHERE m.id IN (:matchIds)
        """)
     fun findMy(matchIds: List<Long>): List<Match>
+
+    fun findAllByGameId(gameId: Long): List<Match>
 }

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -73,6 +73,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/temp-point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/rule/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/game/format/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // match
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -73,7 +73,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/temp-point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/rule/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
-            httpRequests.requestMatchers(HttpMethod.GET, "/stage/game/format/{game_id}").permitAll()
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/game/format/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
 
             // match
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)

--- a/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/SecurityConfig.kt
@@ -73,7 +73,7 @@ class SecurityConfig(
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/temp-point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/point/me/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/rule/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
-            httpRequests.requestMatchers(HttpMethod.GET, "/stage/game/format/{game_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)
+            httpRequests.requestMatchers(HttpMethod.GET, "/stage/game/format/{game_id}").permitAll()
 
             // match
             httpRequests.requestMatchers(HttpMethod.GET, "/stage/match/search/{stage_id}").hasAnyRole(Authority.USER.name, Authority.STAFF.name)


### PR DESCRIPTION
## 개요
토너먼트 경기의 대진표 조회 API를 개발하였습니다.

## 본문
- 토너먼트 경기의 매치들을 round 별로 나누어 각 팀 정보와 승리 팀 정보를 반환합니다.
- 해당 요청을 한 유저가 조회하려는 경기의 스테이지에 참여하고 있는지 검증합니다.
- 매치들 조회시 Game과 MatchResult엔티티 조회 JPQL 쿼리에 패치조인하여 쿼리 성능을 튜닝하였습니다.