### PR TITLE
[stage] 스테이지 관련 API 캐시 적용 및 역직렬화 문제 해결

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
@@ -21,7 +21,7 @@ class GameServiceImpl(
 ) : GameService {
 
     @Transactional(readOnly = true)
-    @Cacheable(value = [CacheConstant.STAGE_GAME_CACHE_VALE], key = "#stageId", cacheManager = "cacheManager")
+    @Cacheable(value = [CacheConstant.GAME_CACHE_VALE], key = "#stageId", cacheManager = "cacheManager")
     override fun queryAll(stageId: Long): QueryGameDto {
         val student = userUtil.getCurrentStudent()
         stageValidator.validStage(student, stageId)
@@ -30,6 +30,7 @@ class GameServiceImpl(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.GAME_FORMAT_CACHE_VALUE], key = "#gameId", cacheManager = "cacheManager")
     override fun queryFormat(gameId: Long): QueryGameFormatDto {
         val student = userUtil.getCurrentStudent()
         val game = gameReader.read(gameId)

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/GameServiceImpl.kt
@@ -4,7 +4,9 @@ import gogo.gogostage.domain.game.application.dto.QueryGameDto
 import gogo.gogostage.domain.game.application.dto.QueryGameFormatDto
 import gogo.gogostage.domain.match.root.application.MatchReader
 import gogo.gogostage.domain.stage.root.application.StageValidator
+import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.util.UserContextUtil
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +21,7 @@ class GameServiceImpl(
 ) : GameService {
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.STAGE_GAME_CACHE_VALE], key = "#stageId", cacheManager = "cacheManager")
     override fun queryAll(stageId: Long): QueryGameDto {
         val student = userUtil.getCurrentStudent()
         stageValidator.validStage(student, stageId)

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -32,15 +32,14 @@ data class QueryGameFormatInfoDto(
 data class QueryGameFormatMatchInfoDto(
     val matchId: Long,
     val turn: Int,
-    @field:JsonProperty("ateamId")
+    @field:JsonProperty("aTeamId")
     val aTeamId: Long?,
-    @field:JsonProperty("ateamName")
+    @field:JsonProperty("aTeamName")
     val aTeamName: String,
-    @field:JsonProperty("bteamId")
+    @field:JsonProperty("bTeamId")
     val bTeamId: Long?,
-    @field:JsonProperty("bteamName")
+    @field:JsonProperty("bTeamName")
     val bTeamName: String,
-    @field:JsonProperty("end")
     val isEnd: Boolean,
     val winTeamId: Long?
 )

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -5,18 +5,18 @@ import gogo.gogostage.domain.game.persistence.GameSystem
 import gogo.gogostage.domain.match.root.persistence.Round
 
 data class QueryGameDto(
-    val count: Int,
-    val games: List<QueryGameInfoDto>
+    val count: Int = 0,
+    val games: List<QueryGameInfoDto> = emptyList(),
 )
 
 data class QueryGameInfoDto(
-    val gameId: Long,
-    val gameName: String,
-    val teamCount: Int,
-    val teamMinCapacity: Int,
-    val teamMaxCapacity: Int,
-    val category: GameCategory,
-    val system: GameSystem,
+    val gameId: Long = 0L,
+    val gameName: String = "",
+    val teamCount: Int = 0,
+    val teamMinCapacity: Int = 0,
+    val teamMaxCapacity: Int = 0,
+    val category: GameCategory = GameCategory.ETC,
+    val system: GameSystem = GameSystem.SINGLE,
 )
 
 data class QueryGameFormatDto(

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -6,41 +6,41 @@ import gogo.gogostage.domain.game.persistence.GameSystem
 import gogo.gogostage.domain.match.root.persistence.Round
 
 data class QueryGameDto(
-    val count: Int = 0,
-    val games: List<QueryGameInfoDto> = emptyList(),
+    val count: Int,
+    val games: List<QueryGameInfoDto>,
 )
 
 data class QueryGameInfoDto(
-    val gameId: Long = 0L,
-    val gameName: String = "",
-    val teamCount: Int = 0,
-    val teamMinCapacity: Int = 0,
-    val teamMaxCapacity: Int = 0,
-    val category: GameCategory = GameCategory.ETC,
-    val system: GameSystem = GameSystem.SINGLE,
+    val gameId: Long,
+    val gameName: String,
+    val teamCount: Int,
+    val teamMinCapacity: Int,
+    val teamMaxCapacity: Int,
+    val category: GameCategory,
+    val system: GameSystem,
 )
 
 data class QueryGameFormatDto(
-    val format: List<QueryGameFormatInfoDto> = emptyList(),
+    val format: List<QueryGameFormatInfoDto>
 )
 
 data class QueryGameFormatInfoDto(
-    val round: Round = Round.FINALS,
-    val match: List<QueryGameFormatMatchInfoDto> = emptyList(),
+    val round: Round,
+    val match: List<QueryGameFormatMatchInfoDto>
 )
 
 data class QueryGameFormatMatchInfoDto(
-    val matchId: Long = 0L,
-    val turn: Int = 0,
+    val matchId: Long,
+    val turn: Int,
     @field:JsonProperty("ateamId")
-    val aTeamId: Long? = null,
+    val aTeamId: Long?,
     @field:JsonProperty("ateamName")
-    val aTeamName: String = "",
+    val aTeamName: String,
     @field:JsonProperty("bteamId")
-    val bTeamId: Long? = null,
+    val bTeamId: Long?,
     @field:JsonProperty("bteamName")
-    val bTeamName: String = "",
+    val bTeamName: String,
     @field:JsonProperty("end")
-    val isEnd: Boolean = false,
-    val winTeamId: Long? = null,
+    val isEnd: Boolean,
+    val winTeamId: Long?
 )

--- a/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/game/application/dto/GameDto.kt
@@ -1,5 +1,6 @@
 package gogo.gogostage.domain.game.application.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.game.persistence.GameSystem
 import gogo.gogostage.domain.match.root.persistence.Round
@@ -20,21 +21,26 @@ data class QueryGameInfoDto(
 )
 
 data class QueryGameFormatDto(
-    val format: List<QueryGameFormatInfoDto>
+    val format: List<QueryGameFormatInfoDto> = emptyList(),
 )
 
 data class QueryGameFormatInfoDto(
-    val round: Round,
-    val match: List<QueryGameFormatMatchInfoDto>,
+    val round: Round = Round.FINALS,
+    val match: List<QueryGameFormatMatchInfoDto> = emptyList(),
 )
 
 data class QueryGameFormatMatchInfoDto(
-    val matchId: Long,
-    val turn: Int,
-    val aTeamId: Long?,
-    val aTeamName: String,
-    val bTeamId: Long?,
-    val bTeamName: String,
-    val isEnd: Boolean,
-    val winTeamId: Long?
+    val matchId: Long = 0L,
+    val turn: Int = 0,
+    @field:JsonProperty("ateamId")
+    val aTeamId: Long? = null,
+    @field:JsonProperty("ateamName")
+    val aTeamName: String = "",
+    @field:JsonProperty("bteamId")
+    val bTeamId: Long? = null,
+    @field:JsonProperty("bteamName")
+    val bTeamName: String = "",
+    @field:JsonProperty("end")
+    val isEnd: Boolean = false,
+    val winTeamId: Long? = null,
 )

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -182,7 +182,7 @@ class MatchProcessor(
 
         redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
         redisCacheService.deleteFromCache("${CacheConstant.GAME_FORMAT_CACHE_VALUE}::${match.game.id}")
-        redisCacheService.deleteFromCache("${CacheConstant.MATCH_INFO_CACHE_VALUE}::${matchId.id}")
+        redisCacheService.deleteFromCache("${CacheConstant.MATCH_INFO_CACHE_VALUE}::${match.id}")
 
         tempPointProcessor.deleteTempPoint(event)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -125,6 +125,7 @@ class MatchProcessor(
         matchResultRepository.save(matchResult)
 
         redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
+        redisCacheService.deleteFromCache("${CacheConstant.GAME_FORMAT_CACHE_VALUE}::${match.game.id}")
 
         tempPointProcessor.addTempPoint(event)
     }
@@ -179,6 +180,7 @@ class MatchProcessor(
         matchResultRepository.deleteByMatchId(match.id)
 
         redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
+        redisCacheService.deleteFromCache("${CacheConstant.GAME_FORMAT_CACHE_VALUE}::${match.game.id}")
 
         tempPointProcessor.deleteTempPoint(event)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -14,6 +14,8 @@ import gogo.gogostage.domain.match.root.persistence.Round
 import gogo.gogostage.domain.stage.participant.temppoint.application.TempPointProcessor
 import gogo.gogostage.domain.team.root.persistence.Team
 import gogo.gogostage.domain.team.root.persistence.TeamRepository
+import gogo.gogostage.global.cache.CacheConstant
+import gogo.gogostage.global.cache.RedisCacheService
 import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import gogo.gogostage.global.kafka.consumer.dto.BatchCancelEvent
@@ -32,7 +34,8 @@ class MatchProcessor(
     private val matchResultRepository: MatchResultRepository,
     private val tempPointProcessor: TempPointProcessor,
     private val gameRepository: GameRepository,
-    private val matchNotificationReader: MatchNotificationReader
+    private val matchNotificationReader: MatchNotificationReader,
+    private val redisCacheService: RedisCacheService
 ) {
 
     fun toggleMatchNotification(match: Match, student: StudentByIdStub): MatchToggleDto {
@@ -121,6 +124,8 @@ class MatchProcessor(
         )
         matchResultRepository.save(matchResult)
 
+        redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
+
         tempPointProcessor.addTempPoint(event)
     }
 
@@ -172,6 +177,8 @@ class MatchProcessor(
         }
 
         matchResultRepository.deleteByMatchId(match.id)
+
+        redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
 
         tempPointProcessor.deleteTempPoint(event)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -126,6 +126,7 @@ class MatchProcessor(
 
         redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
         redisCacheService.deleteFromCache("${CacheConstant.GAME_FORMAT_CACHE_VALUE}::${match.game.id}")
+        redisCacheService.deleteFromCache("${CacheConstant.MATCH_INFO_CACHE_VALUE}::${match.id}")
 
         tempPointProcessor.addTempPoint(event)
     }
@@ -181,6 +182,7 @@ class MatchProcessor(
 
         redisCacheService.deleteFromCache("${CacheConstant.TEAM_CACHE_VALUE}::${match.game.id}")
         redisCacheService.deleteFromCache("${CacheConstant.GAME_FORMAT_CACHE_VALUE}::${match.game.id}")
+        redisCacheService.deleteFromCache("${CacheConstant.MATCH_INFO_CACHE_VALUE}::${matchId.id}")
 
         tempPointProcessor.deleteTempPoint(event)
     }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
@@ -37,7 +37,7 @@ class MatchServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = [CacheConstant.MATCH_INFO_CACHE_VALUE], key = "#matchId")
+    @Cacheable(value = [CacheConstant.MATCH_INFO_CACHE_VALUE], key = "#matchId", cacheManager = "cacheManager")
     override fun info(matchId: Long): MatchInfoDto {
         val student = userUtil.getCurrentStudent()
         val match = matchReader.info(matchId)

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchServiceImpl.kt
@@ -6,7 +6,9 @@ import gogo.gogostage.global.util.UserContextUtil
 import gogo.gogostage.domain.match.root.application.dto.MatchInfoDto
 import gogo.gogostage.domain.match.root.application.dto.MatchSearchDto
 import gogo.gogostage.domain.stage.root.application.StageValidator
+import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.internal.betting.api.BettingApi
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -35,6 +37,7 @@ class MatchServiceImpl(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.MATCH_INFO_CACHE_VALUE], key = "#matchId")
     override fun info(matchId: Long): MatchInfoDto {
         val student = userUtil.getCurrentStudent()
         val match = matchReader.info(matchId)

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -23,13 +23,12 @@ data class MatchToggleDto(
 
 data class MatchInfoDto(
     val matchId: Long,
-    @field:JsonProperty("ateam")
+    @field:JsonProperty("aTeam")
     val aTeam: MatchTeamInfoDto,
-    @field:JsonProperty("bteam")
+    @field:JsonProperty("bTeam")
     val bTeam: MatchTeamInfoDto,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    @field:JsonProperty("end")
     val isEnd: Boolean,
     val round: Round?,
     val category: GameCategory,

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -1,6 +1,7 @@
 package gogo.gogostage.domain.match.root.application.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.game.persistence.GameSystem
 import gogo.gogostage.domain.match.root.persistence.Round
@@ -21,17 +22,20 @@ data class MatchToggleDto(
 )
 
 data class MatchInfoDto(
-    val matchId: Long = 0L,
-    val aTeam: MatchTeamInfoDto = MatchTeamInfoDto(),
-    val bTeam: MatchTeamInfoDto = MatchTeamInfoDto(),
-    val startDate: LocalDateTime = LocalDateTime.now(),
-    val endDate: LocalDateTime = LocalDateTime.now(),
-    val isEnd: Boolean = false,
-    val round: Round? = null,
-    val category: GameCategory = GameCategory.ETC,
-    val system: GameSystem = GameSystem.SINGLE,
-    val gameName: String = "",
-    val turn: Int? = null
+    val matchId: Long,
+    @field:JsonProperty("ateam")
+    val aTeam: MatchTeamInfoDto,
+    @field:JsonProperty("bteam")
+    val bTeam: MatchTeamInfoDto,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime,
+    @field:JsonProperty("end")
+    val isEnd: Boolean,
+    val round: Round?,
+    val category: GameCategory,
+    val system: GameSystem,
+    val gameName: String,
+    val turn: Int?
 )
 
 data class MatchSearchDto(
@@ -58,10 +62,10 @@ data class MatchSearchInfoDto(
 )
 
 data class MatchTeamInfoDto(
-    val teamId: Long? = null,
-    val teamName: String = "",
-    val bettingPoint: Long? = null,
-    val winCount: Int? = null,
+    val teamId: Long?,
+    val teamName: String,
+    val bettingPoint: Long?,
+    val winCount: Int?,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val participants: List<MatchTeamParticipantInfoDto>? = null
 )

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/dto/MatchDto.kt
@@ -21,17 +21,17 @@ data class MatchToggleDto(
 )
 
 data class MatchInfoDto(
-    val matchId: Long,
-    val aTeam: MatchTeamInfoDto,
-    val bTeam: MatchTeamInfoDto,
-    val startDate: LocalDateTime,
-    val endDate: LocalDateTime,
-    val isEnd: Boolean,
-    val round: Round?,
-    val category: GameCategory,
-    val system: GameSystem,
-    val gameName: String,
-    val turn: Int?
+    val matchId: Long = 0L,
+    val aTeam: MatchTeamInfoDto = MatchTeamInfoDto(),
+    val bTeam: MatchTeamInfoDto = MatchTeamInfoDto(),
+    val startDate: LocalDateTime = LocalDateTime.now(),
+    val endDate: LocalDateTime = LocalDateTime.now(),
+    val isEnd: Boolean = false,
+    val round: Round? = null,
+    val category: GameCategory = GameCategory.ETC,
+    val system: GameSystem = GameSystem.SINGLE,
+    val gameName: String = "",
+    val turn: Int? = null
 )
 
 data class MatchSearchDto(
@@ -58,10 +58,10 @@ data class MatchSearchInfoDto(
 )
 
 data class MatchTeamInfoDto(
-    val teamId: Long?,
-    val teamName: String,
-    val bettingPoint: Long?,
-    val winCount: Int?,
+    val teamId: Long? = null,
+    val teamName: String = "",
+    val bettingPoint: Long? = null,
+    val winCount: Int? = null,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val participants: List<MatchTeamParticipantInfoDto>? = null
 )

--- a/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/participant/root/application/ParticipateProcessor.kt
@@ -4,6 +4,8 @@ import gogo.gogostage.domain.match.root.persistence.Match
 import gogo.gogostage.domain.match.root.persistence.MatchRepository
 import gogo.gogostage.domain.stage.participant.root.event.TicketPointMinusEvent
 import gogo.gogostage.domain.stage.participant.root.persistence.StageParticipantRepository
+import gogo.gogostage.global.cache.CacheConstant
+import gogo.gogostage.global.cache.RedisCacheService
 import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.kafka.consumer.dto.MiniGameBetCompletedEvent
 import gogo.gogostage.global.kafka.consumer.dto.TicketShopBuyEvent
@@ -18,7 +20,8 @@ import java.util.*
 class ParticipateProcessor(
     private val matchRepository: MatchRepository,
     private val stageParticipantRepository: StageParticipantRepository,
-    private val applicationEventPublisher: ApplicationEventPublisher
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val redisCacheService: RedisCacheService
 ) {
 
     @Transactional
@@ -34,6 +37,8 @@ class ParticipateProcessor(
 
         stageParticipant.minusPoint(point)
         updateMatchBettingPointTeam(match, predictedWinTeamId, point)
+
+        redisCacheService.deleteFromCache("${CacheConstant.MATCH_INFO_CACHE_VALUE}::${matchId}")
 
         stageParticipantRepository.save(stageParticipant)
         matchRepository.save(match)

--- a/src/main/kotlin/gogo/gogostage/domain/stage/rule/application/StageRuleServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/rule/application/StageRuleServiceImpl.kt
@@ -17,7 +17,7 @@ class StageRuleServiceImpl(
 ) : StageRuleService {
 
     @Transactional(readOnly = true)
-    @Cacheable(value = [CacheConstant.STAGE_RULE_CACHE_VALE], key = "#stageId")
+    @Cacheable(value = [CacheConstant.STAGE_RULE_CACHE_VALE], key = "#stageId", cacheManager = "cacheManager")
     override fun query(stageId: Long): StageRuleDto {
         val student = userUtil.getCurrentStudent()
         stageValidator.validStage(student, stageId)

--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/dto/TeamApplyDto.kt
@@ -20,29 +20,29 @@ data class TeamParticipantDto(
 )
 
 data class GameTeamResDto(
-    val count: Int = 0,
-    val team: List<GameTeamDto> = emptyList(),
+    val count: Int,
+    val team: List<GameTeamDto>,
 )
 
 data class GameTeamDto(
-    val teamId: Long = 0L,
-    val teamName: String = "",
-    val participantCount: Int = 0,
-    val winCount: Int = 0,
+    val teamId: Long,
+    val teamName: String,
+    val participantCount: Int,
+    val winCount: Int,
 )
 
 data class TeamInfoDto(
-    val teamId: Long = 0L,
-    val teamName: String = "",
-    val participantCount: Int = 0,
-    val participant: List<ParticipantDto> = emptyList(),
+    val teamId: Long,
+    val teamName: String,
+    val participantCount: Int,
+    val participant: List<ParticipantDto>,
 )
 
 data class ParticipantDto(
-    val studentId: Long = 0L,
-    val name: String = "",
-    val classNumber: Int = 0,
-    val studentNumber: Int = 0,
-    val positionX: String = "",
-    val positionY: String = "",
+    val studentId: Long,
+    val name: String,
+    val classNumber: Int,
+    val studentNumber: Int,
+    val positionX: String,
+    val positionY: String,
 )

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -7,4 +7,5 @@ object CacheConstant {
     const val STAGE_RULE_CACHE_VALE = "stage_rule"
     const val GAME_CACHE_VALE = "game"
     const val GAME_FORMAT_CACHE_VALUE = "game_format"
+    const val MATCH_INFO_CACHE_VALUE = "match_info"
 }

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -5,4 +5,5 @@ object CacheConstant {
     const val TEMP_TEAM_CACHE_VALUE = "temp_team"
     const val TEAM_INFO_CACHE_VALUE = "team_info"
     const val STAGE_RULE_CACHE_VALE = "stage_rule"
+    const val STAGE_GAME_CACHE_VALE = "stage_game"
 }

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -5,5 +5,6 @@ object CacheConstant {
     const val TEMP_TEAM_CACHE_VALUE = "temp_team"
     const val TEAM_INFO_CACHE_VALUE = "team_info"
     const val STAGE_RULE_CACHE_VALE = "stage_rule"
-    const val STAGE_GAME_CACHE_VALE = "stage_game"
+    const val GAME_CACHE_VALE = "game"
+    const val GAME_FORMAT_CACHE_VALUE = "game_format"
 }

--- a/src/main/kotlin/gogo/gogostage/global/cache/RedisCacheService.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/RedisCacheService.kt
@@ -1,0 +1,15 @@
+package gogo.gogostage.global.cache
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RedisCacheService(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+
+    fun deleteFromCache(key: String) {
+        redisTemplate.delete(key)
+    }
+
+}

--- a/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
@@ -1,10 +1,9 @@
 package gogo.gogostage.global.config
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -13,7 +12,6 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.cache.CacheKeyPrefix
 import org.springframework.data.redis.cache.RedisCacheConfiguration
 import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -50,6 +48,7 @@ class RedisConfig(
             registerModule(KotlinModule.Builder().build())
             registerModule(JavaTimeModule())
             disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder()
                     .allowIfBaseType(Any::class.java)
@@ -70,7 +69,7 @@ class RedisConfig(
 
     @Bean
     fun cacheManager(): CacheManager {
-        val serializer = GenericJackson2JsonRedisSerializer()
+        val serializer = GenericJackson2JsonRedisSerializer(objectMapper())
         val configuration = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
             .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))

--- a/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
+++ b/src/main/kotlin/gogo/gogostage/global/config/RedisConfig.kt
@@ -1,8 +1,6 @@
 package gogo.gogostage.global.config
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
@@ -47,6 +45,8 @@ class RedisConfig(
         return jacksonObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
             registerModule(JavaTimeModule())
+            setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)
+            enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
             disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             activateDefaultTyping(


### PR DESCRIPTION
## 개요
스테이지 관련 API 캐시 적용 및 역직렬화 문제를 해결하였습니다.

## 본문
- 스테이지에 등록된 경기 조회, 매치 상세 조회, 대진표 조회 API의 response를 캐시하였습니다.
- redis cache service를 두어 배팅 이벤트 핸들링시 해당 매치 상세 조회 key 삭제, 정산, 정산취소 이벤트 핸들링시 팀 리스트 조회, 대진표, 매치 상세 조회 key를 삭제 처리하였습니다.

## 이슈
- dto 객체 역직렬화 문제는 object mapper를 cache manger에 등록하고 activateDefaultTyping 설정과 필드 case 관련 설정을 추가하여 해결하였습니다.
- 하지만 `aTeam` 과 같은 필드는 직렬화시 `ateam` 과 같이 직렬화 되기 때문에 `@JsonProperty` 어노테이션으로 직접 매핑시켰습니다. 이로 인해 response에 중복되는 필드가 나타나는 이슈가 발생하였습니다. 추후 해결이 필요해보입니다.

```json
{
    "matchId": 17,
    "aTeam": {
        ...
    },
    "bTeam": {
        ...
    },
    ...
    // 중복 필드
    "ateam": {
        ...
    },
    "bteam": {
        ...
    }
}
```