### PR TITLE
[match] 매치 토글 알림 동시성 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/match/notification/application/MatchNotificationReader.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/notification/application/MatchNotificationReader.kt
@@ -1,8 +1,6 @@
 package gogo.gogostage.domain.match.notification.application
 
 import gogo.gogostage.domain.match.notification.persistence.MatchNotificationRepository
-import gogo.gogostage.global.error.StageException
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 
 @Component
@@ -12,6 +10,6 @@ class MatchNotificationReader(
 
     fun readByMatchIdAndStudentIdForWrite(matchId: Long, studentId: Long) =
         matchNotificationRepository.findByMatchIdAndStudentIdForWrite(matchId, studentId)
-            ?: throw StageException("MatchNotification Not Found, matchId=$matchId, studentId=$studentId", HttpStatus.NOT_FOUND.value())
+
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/match/root/application/MatchProcessor.kt
@@ -39,25 +39,17 @@ class MatchProcessor(
 ) {
 
     fun toggleMatchNotification(match: Match, student: StudentByIdStub): MatchToggleDto {
-        if (matchNotificationRepository.existsByMatchIdAndStudentId(match.id, student.studentId)) {
-            val matchNotification = matchNotificationReader.readByMatchIdAndStudentIdForWrite(match.id, student.studentId)
+        val matchNotification = matchNotificationReader.readByMatchIdAndStudentIdForWrite(match.id, student.studentId)
 
+        if (matchNotification != null) {
             matchNotificationRepository.delete(matchNotification)
-
-            return MatchToggleDto(
-                isNotice = false
-            )
+            return MatchToggleDto(isNotice = false)
         } else {
-            val matchNotification = MatchNotification(
+            matchNotificationRepository.save(MatchNotification(
                 match = match,
                 studentId = student.studentId
-            )
-
-            matchNotificationRepository.save(matchNotification)
-
-            return MatchToggleDto(
-                isNotice = true
-            )
+            ))
+            return MatchToggleDto(isNotice = true)
         }
     }
 


### PR DESCRIPTION
# 개요
match 알림 토클 api에서 동시성 문제가 발생하여 로직으로 해결하였습니다.

# 본문
서비스 로직에서 exist를 먼저 실행하는데 이때 동시에 접근하게 되면 row lock이 걸리지 않아 false로 뜰 경우 동시에 2개가 생성되는 문제가 생겨 조회할 때 nullable로 만들어 row lock을 걸고 그 뒤 if문으로 나뉘게 리팩토링하였습니다