### PR TITLE
[community] 커뮤니티 관련 API 캐싱

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -24,7 +24,6 @@ class CommunityProcessor(
     private val commentLikeRepository: CommentLikeRepository,
     private val commentMapper: CommunityMapper,
     private val boardRepository: BoardRepository,
-    private val redisCacheService: RedisCacheService
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeResDto {
@@ -39,8 +38,6 @@ class CommunityProcessor(
             board.minusLikeCount()
             boardRepository.save(board)
 
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
-
             return LikeResDto(
                 isLiked = false
             )
@@ -54,8 +51,6 @@ class CommunityProcessor(
 
             board.plusLikeCount()
             boardRepository.save(board)
-
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
 
             return LikeResDto(
                 isLiked = true
@@ -82,8 +77,6 @@ class CommunityProcessor(
         board.plusCommentCount()
         boardRepository.save(board)
 
-        redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
-
         return commentMapper.mapWriteBoardCommentResDto(comment, writeBoardCommentDto, student)
     }
 
@@ -99,8 +92,6 @@ class CommunityProcessor(
             comment.minusLikeCount()
             commentRepository.save(comment)
 
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
-
             return LikeResDto(
                 isLiked = false
             )
@@ -114,8 +105,6 @@ class CommunityProcessor(
 
             comment.plusLikeCount()
             commentRepository.save(comment)
-
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
 
             return LikeResDto(
                 isLiked = true

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -9,6 +9,8 @@ import gogo.gogostage.domain.community.comment.persistence.CommentRepository
 import gogo.gogostage.domain.community.commentlike.persistence.CommentLike
 import gogo.gogostage.domain.community.commentlike.persistence.CommentLikeRepository
 import gogo.gogostage.domain.community.root.application.dto.*
+import gogo.gogostage.global.cache.CacheConstant
+import gogo.gogostage.global.cache.RedisCacheService
 import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.http.HttpStatus
@@ -21,7 +23,8 @@ class CommunityProcessor(
     private val commentRepository: CommentRepository,
     private val commentLikeRepository: CommentLikeRepository,
     private val commentMapper: CommunityMapper,
-    private val boardRepository: BoardRepository
+    private val boardRepository: BoardRepository,
+    private val redisCacheService: RedisCacheService
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeResDto {
@@ -36,6 +39,8 @@ class CommunityProcessor(
             board.minusLikeCount()
             boardRepository.save(board)
 
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
+
             return LikeResDto(
                 isLiked = false
             )
@@ -49,6 +54,8 @@ class CommunityProcessor(
 
             board.plusLikeCount()
             boardRepository.save(board)
+
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
 
             return LikeResDto(
                 isLiked = true
@@ -75,6 +82,8 @@ class CommunityProcessor(
         board.plusCommentCount()
         boardRepository.save(board)
 
+        redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}")
+
         return commentMapper.mapWriteBoardCommentResDto(comment, writeBoardCommentDto, student)
     }
 
@@ -90,6 +99,8 @@ class CommunityProcessor(
             comment.minusLikeCount()
             commentRepository.save(comment)
 
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
+
             return LikeResDto(
                 isLiked = false
             )
@@ -103,6 +114,8 @@ class CommunityProcessor(
 
             comment.plusLikeCount()
             commentRepository.save(comment)
+
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
 
             return LikeResDto(
                 isLiked = true

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -6,7 +6,9 @@ import gogo.gogostage.domain.community.root.application.dto.*
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.stage.root.application.StageValidator
+import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.util.UserContextUtil
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -41,6 +43,7 @@ class CommunityServiceImpl(
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId", cacheManager = "cacheManager")
     override fun getStageBoardInfo(boardId: Long): GetCommunityBoardInfoResDto {
         val student = userUtil.getCurrentStudent()
         val board = boardReader.read(boardId)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -8,6 +8,7 @@ import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.stage.root.application.StageValidator
 import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.util.UserContextUtil
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -54,6 +55,7 @@ class CommunityServiceImpl(
     }
 
     @Transactional
+    @CacheEvict(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId", cacheManager = "cacheManager")
     override fun likeStageBoard(boardId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardIdForWrite(boardId)
@@ -62,6 +64,7 @@ class CommunityServiceImpl(
     }
 
     @Transactional
+    @CacheEvict(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId", cacheManager = "cacheManager")
     override fun writeBoardComment(boardId: Long, writeBoardCommentDto: WriteBoardCommentReqDto): WriteBoardCommentResDto {
         val student = userUtil.getCurrentStudent()
         val board = communityReader.readBoardByBoardId(boardId)
@@ -71,6 +74,7 @@ class CommunityServiceImpl(
     }
 
     @Transactional
+    @CacheEvict(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId", cacheManager = "cacheManager")
     override fun likeBoardComment(commentId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
         val comment = communityReader.readCommentByCommentIdForWrite(commentId)

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -8,4 +8,5 @@ object CacheConstant {
     const val GAME_CACHE_VALE = "game"
     const val GAME_FORMAT_CACHE_VALUE = "game_format"
     const val MATCH_INFO_CACHE_VALUE = "match_info"
+    const val COMMUNITY_INFO_CACHE_VALUE = "community_info"
 }

--- a/src/main/kotlin/gogo/gogostage/global/internal/user/stub/Sex.kt
+++ b/src/main/kotlin/gogo/gogostage/global/internal/user/stub/Sex.kt
@@ -1,5 +1,10 @@
 package gogo.gogostage.global.internal.user.stub
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 enum class Sex {
-    MALE, FEMALE
+    @JsonProperty("MALE")
+    MALE,
+    @JsonProperty("FEMALE")
+    FEMALE
 }


### PR DESCRIPTION
# 개요
커뮤니티 관련 API를 redis를 사용하여 캐싱하였습니다.

# 본문
* boardInfo api에 레디스 캐시를 설정하였고 게시글 좋아요, 댓글 작성, 댓글 좋아요를 하게 되면 캐시를 지우게 설정하였습니다.
// 게시글 모두 불러오기 api는 페이징과 캐시를 remove해야되는 시점에서 key를 설정하기 적합하지 않아 캐싱하지 않았습니다.

<img width="882" alt="스크린샷 2025-04-09 오전 10 21 54" src="https://github.com/user-attachments/assets/335fd18c-fe42-4cd4-88d8-fee460f9f5e9" />
<img width="878" alt="스크린샷 2025-04-09 오전 10 25 55" src="https://github.com/user-attachments/assets/eff61861-bc6c-4c1d-b639-a59289d7df25" />
