### PR TITLE
[stage] 랭킹 조회 쿼리 커버링 인덱스 적용

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/application/dto/StageDto.kt
@@ -170,6 +170,12 @@ data class QueryMyStageInfoDto(
     val isMaintaining: Boolean
 )
 
+data class StageParticipantPointOnly(
+    val id: Long,
+    val studentId: Long,
+    val point: Long
+)
+
 data class StageParticipantPointRankDto(
     val info: PageDto,
     val rank: List<PointRankDto>

--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
@@ -1,10 +1,12 @@
 package gogo.gogostage.domain.stage.root.persistence
 
 import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 import gogo.gogostage.domain.stage.participant.root.persistence.QStageParticipant.stageParticipant
 import gogo.gogostage.domain.stage.root.application.dto.PageDto
 import gogo.gogostage.domain.stage.root.application.dto.PointRankDto
+import gogo.gogostage.domain.stage.root.application.dto.StageParticipantPointOnly
 import gogo.gogostage.domain.stage.root.application.dto.StageParticipantPointRankDto
 import gogo.gogostage.global.internal.student.api.StudentApi
 import org.springframework.data.domain.Pageable
@@ -21,7 +23,16 @@ class StageCustomRepositoryImpl(
 
         predicate.and(stageParticipant.stage.id.eq(stage.id))
 
-        val studentParticipants = queryFactory.selectFrom(stageParticipant)
+        val studentParticipants = queryFactory
+            .select(
+                Projections.constructor(
+                    StageParticipantPointOnly::class.java,
+                    stageParticipant.id,
+                    stageParticipant.studentId,
+                    stageParticipant.point
+                )
+            )
+            .from(stageParticipant)
             .where(predicate)
             .orderBy(stageParticipant.point.desc())
             .offset(pageable.offset)


### PR DESCRIPTION
## 개요
랭킹 조회 쿼리에서 커버링 인덱스를 적용하기 위해 조회에 필요한 컬럼만 조회하도록 프로젝션을 적용하였습니다.

## 본문
- 랭킹 조회시 tbl_stage_participant 테이블에 id, studentId, point row를 필요로 합니다.
- 해당 row들로 이루어진 인덱스를 생성하면 랭킹 조회 성능이 개선됩니다.
- 커버링 인덱스를 사용할 수 있도록 랭킹 조회 쿼리에서 필요한 row들만 (id, studentId, point) 조회하도록 수정하였습니다.
- 인덱스 생성 DDL 쿼리는 노션 문서 -> 세컨터리 인덱스 설계 페이지를 참고해주세요.

<img width="152" alt="스크린샷 2025-04-10 11 49 58" src="https://github.com/user-attachments/assets/49416cbb-f9bd-424e-8a8f-c62634e0871b" />

> 기존 랭킹 조회

<img width="135" alt="스크린샷 2025-04-10 11 50 08" src="https://github.com/user-attachments/assets/7e13b9d3-9ea5-497a-84c8-d8f9c9d68ea1" />

> 커버링 인덱스 적용 후

<img width="406" alt="스크린샷 2025-04-10 11 50 23" src="https://github.com/user-attachments/assets/ea253e48-3a4d-4a0e-a077-c5eb4e4295f7" />
