### PR TITLE
[community] 올바르지 않은 key로 캐시 삭제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -24,6 +24,7 @@ class CommunityProcessor(
     private val commentLikeRepository: CommentLikeRepository,
     private val commentMapper: CommunityMapper,
     private val boardRepository: BoardRepository,
+    private val redisCacheService: RedisCacheService
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeResDto {
@@ -89,6 +90,8 @@ class CommunityProcessor(
 
             commentLikeRepository.delete(commentLike)
 
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
+
             comment.minusLikeCount()
             commentRepository.save(comment)
 
@@ -102,6 +105,8 @@ class CommunityProcessor(
             )
 
             commentLikeRepository.save(boardLike)
+
+            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}")
 
             comment.plusLikeCount()
             commentRepository.save(comment)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -74,7 +74,6 @@ class CommunityServiceImpl(
     }
 
     @Transactional
-    @CacheEvict(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId", cacheManager = "cacheManager")
     override fun likeBoardComment(commentId: Long): LikeResDto {
         val student = userUtil.getCurrentStudent()
         val comment = communityReader.readCommentByCommentIdForWrite(commentId)


### PR DESCRIPTION
# 개요
댓글 좋아요를 누를 때 파라미터에 존재하지 않은 값으로 삭제를 시도해여 오류가 발생해 수정하였습니다.

# 본문
service 메서드에서 진행하던 CacheEvict를 processor에서 redisCache를 직접 제거하는 방식으로 변경하였습니다.