### PR TITLE
[internal] betting service client fallback, ciurcuitbreaker 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
 extra["springCloudVersion"] = "2024.0.0-RC1"
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")

--- a/src/main/kotlin/gogo/gogostage/global/feign/client/BettingClient.kt
+++ b/src/main/kotlin/gogo/gogostage/global/feign/client/BettingClient.kt
@@ -1,12 +1,14 @@
 package gogo.gogostage.global.feign.client
 
+import gogo.gogostage.global.feign.fallback.BettingClientFallbackFactory
 import gogo.gogostage.global.internal.betting.stub.BettingBundleDto
 import gogo.gogostage.global.internal.betting.stub.TotalBettingPointDto
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 
-@FeignClient(name = "gogo-betting")
+@FeignClient(name = "gogo-betting", fallbackFactory = BettingClientFallbackFactory::class)
 interface BettingClient {
     @GetMapping("/betting/bundle")
     fun bundle(

--- a/src/main/kotlin/gogo/gogostage/global/feign/fallback/BettingClientFallbackFactory.kt
+++ b/src/main/kotlin/gogo/gogostage/global/feign/fallback/BettingClientFallbackFactory.kt
@@ -1,0 +1,32 @@
+package gogo.gogostage.global.feign.fallback
+
+import gogo.gogostage.global.feign.client.BettingClient
+import gogo.gogostage.global.filter.LoggingFilter
+import gogo.gogostage.global.internal.betting.stub.BettingBundleDto
+import gogo.gogostage.global.internal.betting.stub.TotalBettingPointDto
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.cloud.openfeign.FallbackFactory
+import org.springframework.stereotype.Component
+
+@Component
+class BettingClientFallbackFactory : FallbackFactory<BettingClient> {
+
+    private val log: Logger = LoggerFactory.getLogger(LoggingFilter::class.java)
+
+    override fun create(cause: Throwable): BettingClient {
+        return object : BettingClient {
+            override fun bundle(matchIds: List<Long>, studentId: Long): BettingBundleDto {
+                log.error("BettingClient.bundle FallBack - matchIds: $matchIds, studentId: $studentId")
+                return BettingBundleDto(
+                    bettings = emptyList(),
+                )
+            }
+
+            override fun totalBettingPoint(matchIds: List<Long>, studentId: Long): TotalBettingPointDto {
+                log.error("BettingClient.totalBettingPoint FallBack - matchIds: $matchIds, studentId: $studentId")
+                throw cause
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
매치 검색시 사용하는 배팅 정보 일괄 조회 internal API client에서 오류 발생시 fallback 처리와 circuitbreaker를 적용하였습니다.

## 본문
- 매치 검색시 Betting Service에 동기 HTTP 요청을 하게 되는데 요청하는 서비스에서 장애 발생시 매치 검색도 되지 않는 장애 전파 문제 있습니다.
- internal API 요청중 문제 발생시 fallback 메서드를 실행하도록 하였고, 아래의 설정에 의해 임계치 이상 실패시 circuitbreaker가 OPEN 되도록하여 장애 발생 서비스를 격리시킵니다.

```yaml
resilience4j:
  circuitbreaker:
    configs:
      default:
        failure-rate-threshold: 50
        slow-call-rate-threshold: 80
        slow-call-duration-threshold: 5s
        permitted-number-of-calls-in-half-open-state: 3
        max-wait-duration-in-half-open-state: 0
        sliding-window-type: COUNT_BASED
        sliding-window-size: 20
        minimum-number-of-calls: 10
        wait-duration-in-open-state: 15s
```