### PR TITLE
[community] 커뮤니티 게시글 / 댓글 좋아요 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -3,8 +3,6 @@ package gogo.gogostage.domain.community.root.persistence
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import gogo.gogostage.domain.community.board.persistence.Board
-import gogo.gogostage.domain.community.board.persistence.BoardRepository
-import gogo.gogostage.domain.community.board.persistence.QBoard
 import gogo.gogostage.domain.community.board.persistence.QBoard.board
 import gogo.gogostage.domain.community.boardlike.persistence.BoardLikeRepository
 import gogo.gogostage.domain.community.comment.persistence.QComment.comment
@@ -128,11 +126,14 @@ class CommunityCustomRepositoryImpl(
 
         val commentStudentIds = comments.map { it.studentId }.toSet().toList()
 
+        val commentIds = comments.map { it.id }.toSet().toList()
+
         val commentLikeCommentIds = queryFactory.select(commentLike.comment.id)
             .from(commentLike)
-            .where(commentLike.comment.board.id.eq(board.id).and(
+            .where(
                 commentLike.studentId.eq(student.studentId)
-            ))
+                    .and(commentLike.comment.id.`in`(commentIds))
+            )
             .fetch()
 
         val commentStudents = studentApi.queryByStudentsIds(commentStudentIds)


### PR DESCRIPTION
# 개요
좋아요를 누르지 않아도 게시글과 댓글에 좋아요가 눌러져있는 문제가 발생하여 쿼리를 더욱 정밀하게 변경하였습니다.

# 본문
* commentLikeCommentIds를 boardId로 where을 걸어 하였다면 해당 board.commentIds를 불러와 해당 studentId가 존재하는 것과 commentIds 가 commentLike.comment.id 와 in 절을 사용하여 조회하도록 수정하였습니다.

* boardLike는 쿼리상 문제가 보이지 않았습니다. 테스트 시에도 발생하지 않았습니다