### PR TITLE
[rank] 랭킹에서 동일인물 중복 반환

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
@@ -39,7 +39,7 @@ class StageCustomRepositoryImpl(
             .limit(pageable.pageSize.toLong())
             .fetch()
 
-        val studentIds = studentParticipants.map { it.studentId }
+        val studentIds = studentParticipants.map { it.studentId }.toSet().toList()
 
         val students = studentApi.queryByStudentsIds(studentIds).students
 


### PR DESCRIPTION
# 개요
랭킹 리스트를 반환하는 도중에 동알인물이 중복으로 반환되는 상황이 생겨 수정하였습니다.

# 본문
studentParticipants를 조회 후 studentIds를 추출하는 중에 중복된 id가 들어가는 상황이 생겨 .toSet().toList()를 사용하여 중복을 방지하였습니다.