### PR TITLE
[community] 게시글 상세 조회 캐시 이슈로 인해 제거

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -9,8 +9,6 @@ import gogo.gogostage.domain.community.comment.persistence.CommentRepository
 import gogo.gogostage.domain.community.commentlike.persistence.CommentLike
 import gogo.gogostage.domain.community.commentlike.persistence.CommentLikeRepository
 import gogo.gogostage.domain.community.root.application.dto.*
-import gogo.gogostage.global.cache.CacheConstant
-import gogo.gogostage.global.cache.RedisCacheService
 import gogo.gogostage.global.error.StageException
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import org.springframework.data.repository.findByIdOrNull
@@ -26,7 +24,6 @@ class CommunityProcessor(
     private val commentLikeRepository: CommentLikeRepository,
     private val commentMapper: CommunityMapper,
     private val boardRepository: BoardRepository,
-    private val redisCacheService: RedisCacheService
 ) {
 
     fun likeBoard(studentId: Long, board: Board): LikeResDto {
@@ -41,9 +38,6 @@ class CommunityProcessor(
             board.minusLikeCount()
             boardRepository.save(board)
 
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}:true")
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}:false")
-
             return LikeResDto(
                 isLiked = false
             )
@@ -57,9 +51,6 @@ class CommunityProcessor(
 
             board.plusLikeCount()
             boardRepository.save(board)
-
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}:true")
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${board.id}:false")
 
             return LikeResDto(
                 isLiked = true
@@ -86,9 +77,6 @@ class CommunityProcessor(
         board.plusCommentCount()
         boardRepository.save(board)
 
-        redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:true")
-        redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:false")
-
         return commentMapper.mapWriteBoardCommentResDto(comment, writeBoardCommentDto, student)
     }
 
@@ -100,10 +88,6 @@ class CommunityProcessor(
                 ?: throw StageException("CommentLike Not Found, commentId=${comment.id}, studentId=${student.studentId}", HttpStatus.NOT_FOUND.value())
 
             commentLikeRepository.delete(commentLike)
-
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:true")
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:false")
-
             comment.minusLikeCount()
             commentRepository.save(comment)
 
@@ -117,9 +101,6 @@ class CommunityProcessor(
             )
 
             commentLikeRepository.save(boardLike)
-
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:true")
-            redisCacheService.deleteFromCache("${CacheConstant.COMMUNITY_INFO_CACHE_VALUE}::${comment.board.id}:false")
 
             comment.plusLikeCount()
             commentRepository.save(comment)

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityServiceImpl.kt
@@ -8,11 +8,8 @@ import gogo.gogostage.domain.community.root.event.CommentCreateEvent
 import gogo.gogostage.domain.community.root.persistence.SortType
 import gogo.gogostage.domain.game.persistence.GameCategory
 import gogo.gogostage.domain.stage.root.application.StageValidator
-import gogo.gogostage.global.cache.CacheConstant
 import gogo.gogostage.global.internal.student.stub.StudentByIdStub
 import gogo.gogostage.global.util.UserContextUtil
-import org.springframework.cache.annotation.CacheEvict
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -54,7 +51,6 @@ class CommunityServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = [CacheConstant.COMMUNITY_INFO_CACHE_VALUE], key = "#boardId + ':' + #isFiltered", cacheManager = "cacheManager")
     override fun getStageBoardInfo(boardId: Long, isFiltered: Boolean, student: StudentByIdStub): GetCommunityBoardInfoResDto {
         val board = boardReader.read(boardId)
         stageValidator.validStage(student, board.community.stage.id)

--- a/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
+++ b/src/main/kotlin/gogo/gogostage/global/cache/CacheConstant.kt
@@ -8,5 +8,4 @@ object CacheConstant {
     const val GAME_CACHE_VALE = "game"
     const val GAME_FORMAT_CACHE_VALUE = "game_format"
     const val MATCH_INFO_CACHE_VALUE = "match_info"
-    const val COMMUNITY_INFO_CACHE_VALUE = "community_info"
 }


### PR DESCRIPTION
## 개요
게시글 조회에 적용되어있는 캐시에 이슈가 발생하여 제거하였습니다.

## 본문
- 게시글 상세 조회 api 스펙에 각 유저의 상태 값(isLiked)을 글로벌 캐시하여 여러 유저의 상태 값이 올바르지 않게 조회되었습니다.
- 이로인해 현재 구조에서는 우선 캐시 적용을 제거하여 문제를 해결하고 추후 더 나은 해결 방법을 고민해보는게 좋다고 판단하였습니다.