### PR TITLE
[stage] rank 인원 순서 페이징 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/stage/root/persistence/StageCustomRepositoryImpl.kt
@@ -34,7 +34,10 @@ class StageCustomRepositoryImpl(
             )
             .from(stageParticipant)
             .where(predicate)
-            .orderBy(stageParticipant.point.desc())
+            .orderBy(
+                stageParticipant.point.desc(),
+                stageParticipant.studentId.asc()
+            )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()


### PR DESCRIPTION
# 개요
랭크 페이징을 하면서 orderBy의 조건문을 포인트의 내림차순으로 정렬하여 페이징할 떄마다 값이 달라지는 문제가 생겨 수정하였습니다.

# 본문
* point만으로 내림차순으로 하게 되면 매번 요청마다의 순서가 보장되지 않아 orderBy에 studentId를 오름차순 정렬도 추가하였습니다.