### PR TITLE
[community] 커뮤니티 게시글 이미지 업로드

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/application/BoardProcessor.kt
@@ -26,7 +26,8 @@ class BoardProcessor(
             commentCount = 0,
             likeCount = 0,
             isFiltered = false,
-            createdAt = LocalDateTime.now()
+            createdAt = LocalDateTime.now(),
+            imageUrl = writeCommunityBoardDto.imageUrl,
         )
 
         return boardRepository.save(board)

--- a/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/board/persistence/Board.kt
@@ -35,7 +35,10 @@ class Board(
     var isFiltered: Boolean,
 
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
+
+    @Column(name = "image_url", length = 800, nullable = true)
+    val imageUrl: String,
 ) {
 
     fun minusLikeCount() {

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -15,7 +15,8 @@ data class WriteCommunityBoardDto(
     @Size(max = 1000)
     val content: String,
     @NotNull
-    val gameCategory: GameCategory
+    val gameCategory: GameCategory,
+    val imageUrl: String,
 )
 
 data class GetCommunityBoardResDto(

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/dto/CommunityDto.kt
@@ -49,6 +49,7 @@ data class GetCommunityBoardInfoResDto(
     val isLiked: Boolean,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val createdAt: LocalDateTime,
+    val imageUrl: String,
     val stage: StageDto,
     val commentCount: Int,
     val comment: List<CommentDto>

--- a/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/persistence/CommunityCustomRepositoryImpl.kt
@@ -123,7 +123,8 @@ class CommunityCustomRepositoryImpl(
             createdAt = board.createdAt,
             stage = stageDto,
             commentCount = board.commentCount,
-            comment = commentDto
+            comment = commentDto,
+            imageUrl = board.imageUrl
         )
 
         return response


### PR DESCRIPTION
# 개요
커뮤니티 게시글에 이미지를 업로드 할 수 있도록 컬럼을 추가하였습니다.

# 본문
Image Upload API를 사용하여 반환된 url을 해당 필드에 넣어 요청을 보내면 Board 테이블에 존재하는 imageUrl에 추가 됩니다.