### PR TITLE
[image] 이미지 유효성 검사 로직 변경

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
@@ -8,16 +8,21 @@ import org.springframework.web.multipart.MultipartFile
 class ImageValidator {
 
     fun validImage(image: MultipartFile) {
-        val list = listOf("jpg", "png", "gif")
-        val splitFile = image.originalFilename.toString().split(".")
+        val allowedExtensions = listOf("jpg", "png", "gif")
+        val maxFileSize = 10 * 1024 * 1024 // 10MB
 
-        if(splitFile.size != 2)
+        val fileName = image.originalFilename ?: throw StageException("No file name", 400)
+
+        val extension = fileName.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+
+        if (extension.isBlank() || extension !in allowedExtensions) {
             throw StageException("Image Extension Invalid", 400)
+        }
 
-        val extension = splitFile[1].lowercase()
-
-        if(list.none { it == extension })
-            throw StageException("Image Extension Invalid", 400)
+        if (image.size > maxFileSize) {
+            throw StageException("Image Size Exceeds 10MB", 400)
+        }
     }
+
 
 }

--- a/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
@@ -19,7 +19,7 @@ class ImageValidator {
             throw StageException("Image Extension Invalid", 400)
         }
 
-        if (image.size > maxFileSize) {
+        if (image.size >= maxFileSize) {
             throw StageException("Image Size Exceeds 10MB", 400)
         }
     }

--- a/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/image/application/ImageValidator.kt
@@ -9,7 +9,7 @@ class ImageValidator {
 
     fun validImage(image: MultipartFile) {
         val allowedExtensions = listOf("jpg", "png", "gif")
-        val maxFileSize = 10 * 1024 * 1024 // 10MB
+        val maxFileSize = 10 * 1024 * 1024
 
         val fileName = image.originalFilename ?: throw StageException("No file name", 400)
 


### PR DESCRIPTION
# 개요
이미지 이름이 유효성 검사에서 올바른 이름이라도 통과되지 않아 수정하였습니다.

# 본문
"." 으로 이름과 확장자를 검사하던 것을 마지막 "."으로 확장자를 가져오도록 하였고 만약 확장자가 없다면 빈 문자열을 넣어 if문에 걸리도록 하였습니다. 또한, 파일의 크기도 검사하는 로직을 추가하였습니다.