### PR TITLE
[team] 팀 등록시 경기 캐시 이빅트

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/team/root/application/TeamProcessor.kt
@@ -7,13 +7,16 @@ import gogo.gogostage.domain.team.participant.persistence.TeamParticipantReposit
 import gogo.gogostage.domain.team.root.application.dto.TeamApplyDto
 import gogo.gogostage.domain.team.root.persistence.Team
 import gogo.gogostage.domain.team.root.persistence.TeamRepository
+import gogo.gogostage.global.cache.CacheConstant
+import gogo.gogostage.global.cache.RedisCacheService
 import org.springframework.stereotype.Component
 
 @Component
 class TeamProcessor(
     private val teamRepository: TeamRepository,
     private val teamParticipantRepository: TeamParticipantRepository,
-    private val gameRepository: GameRepository
+    private val gameRepository: GameRepository,
+    private val redisCacheService: RedisCacheService
 ) {
 
     fun apply(game: Game, dto: TeamApplyDto) {
@@ -27,6 +30,8 @@ class TeamProcessor(
             TeamParticipant.of(team, it.studentId, it.positionX, it.positionY)
         }
         teamParticipantRepository.saveAll(participants)
+
+        redisCacheService.deleteFromCache("${CacheConstant.GAME_CACHE_VALE}::${game.stage.id}")
     }
 
 }


### PR DESCRIPTION
## 개요
팀을 등록하였는데 경기 조회 API의 teamCount가 업데이트 되지 않고 반환되는 문제가 발생하였습니다.
-> 팀 등록시 경기 캐시를 이빅트 하도록 수정하였습니다.