### PR TITLE
[community] 게시글 조회수 저장 중 studentId 초기화 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -144,7 +144,7 @@ class CommunityProcessor(
         if (!boardViewRepository.existsByBoardIdAndStudentId(board.id, board.studentId)) {
             val newBoardView = BoardView(
                 board = board,
-                studentId = board.studentId,
+                studentId = event.studentId,
             )
 
             boardViewRepository.save(newBoardView)


### PR DESCRIPTION
# 개요
커뮤니티 게시글을 조회시 조회한 유저를 저장하는 중 이벤트 핸들러에서 조회한 학생의 id가 아닌 작성자의 id를 넣어 수정하였습니다.

# 본문
BoardView 초기화시 authorId가 아닌 event 안에 studentId를 넣도록 수정하였습니다