### PR TITLE
[community] 커뮤니티 게시글 조회수 문제

### DIFF
--- a/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
+++ b/src/main/kotlin/gogo/gogostage/domain/community/root/application/CommunityProcessor.kt
@@ -141,10 +141,10 @@ class CommunityProcessor(
     fun saveBoardView(event: BoardViewEvent) {
         val board = boardReader.read(event.boardId)
 
-        if (!boardViewRepository.existsByBoardIdAndStudentId(board.id, board.studentId)) {
+        if (!boardViewRepository.existsByBoardIdAndStudentId(board.id, event.studentId)) {
             val newBoardView = BoardView(
                 board = board,
-                studentId = board.studentId,
+                studentId = event.studentId,
             )
 
             boardViewRepository.save(newBoardView)


### PR DESCRIPTION
# 개요
커뮤니티 게시글 조회수를 저장하면서 board에 있는 studentId를 넣어 작성자가 아니면 조회수가 계속 늘어나는 문제가 생겨 수정하였습니다.

# 본문
board에서 studentId를 가져오는 것을 event에서 studentId를 가져오도록 수정하였습니다.